### PR TITLE
Add assignee timeline calendar view

### DIFF
--- a/timeline.html
+++ b/timeline.html
@@ -1,0 +1,795 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>担当者タイムライン</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: rgba(15, 23, 42, 0.85);
+      --text: #f8fafc;
+      --muted: #94a3b8;
+      --accent: #38bdf8;
+      --accent-2: #22c55e;
+      --danger: #f87171;
+      --warning: #facc15;
+      --info: #818cf8;
+      --border: rgba(148, 163, 184, 0.2);
+      --shadow: 0 10px 36px rgba(8, 15, 40, 0.5);
+    }
+
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+      background: radial-gradient(1400px 900px at 20% -10%, #132047, #0f172a 55%);
+      color: var(--text);
+      font-family: "Segoe UI", "Hiragino Sans", "Noto Sans JP", "Yu Gothic", sans-serif;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .toolbar {
+      position: sticky;
+      top: 0;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 18px;
+      background: rgba(15, 23, 42, 0.75);
+      backdrop-filter: blur(10px);
+      box-shadow: var(--shadow);
+      z-index: 100;
+    }
+
+    .title {
+      font-weight: 600;
+      font-size: 18px;
+      letter-spacing: 0.03em;
+    }
+
+    .toolbar-spacer {
+      flex: 1;
+    }
+
+    .btn {
+      appearance: none;
+      border: 0;
+      cursor: pointer;
+      padding: 8px 14px;
+      border-radius: 10px;
+      background: rgba(56, 189, 248, 0.15);
+      color: #e0f2fe;
+      border: 1px solid rgba(56, 189, 248, 0.45);
+      transition: transform .1s ease, background .2s ease;
+      font-size: 14px;
+    }
+
+    .btn:hover {
+      transform: translateY(-1px);
+      background: rgba(56, 189, 248, 0.25);
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, #2563eb, #0ea5e9);
+      color: #f8fafc;
+      border-color: transparent;
+    }
+
+    .btn-ghost {
+      background: transparent;
+      border-color: rgba(148, 163, 184, 0.4);
+      color: var(--muted);
+    }
+
+    .page {
+      padding: 18px 18px 36px;
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+    }
+
+    .panel {
+      background: var(--panel);
+      border-radius: 18px;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      padding: 18px;
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      align-items: flex-end;
+    }
+
+    .controls .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-width: 160px;
+    }
+
+    .controls label {
+      font-size: 12px;
+      color: var(--muted);
+      letter-spacing: 0.04em;
+    }
+
+    .controls input[type="date"] {
+      background: rgba(15, 23, 42, 0.9);
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      border-radius: 10px;
+      color: var(--text);
+      padding: 7px 10px;
+      min-height: 36px;
+    }
+
+    .controls .quick {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .controls .quick button {
+      font-size: 13px;
+      padding: 6px 10px;
+      border-radius: 8px;
+      background: rgba(129, 140, 248, 0.15);
+      color: #c7d2fe;
+      border: 1px solid rgba(129, 140, 248, 0.35);
+      cursor: pointer;
+    }
+
+    .controls .quick button:hover {
+      background: rgba(129, 140, 248, 0.25);
+    }
+
+    .summary {
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    .timeline-wrapper {
+      overflow: auto;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.72);
+    }
+
+    table.timeline {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+      min-width: 640px;
+      font-size: 13px;
+    }
+
+    table.timeline thead th {
+      position: sticky;
+      top: 0;
+      background: rgba(15, 23, 42, 0.92);
+      backdrop-filter: blur(4px);
+      z-index: 2;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+      padding: 10px 12px;
+      white-space: nowrap;
+      text-align: center;
+      color: #e2e8f0;
+      font-weight: 600;
+    }
+
+    table.timeline tbody th {
+      position: sticky;
+      left: 0;
+      background: rgba(15, 23, 42, 0.95);
+      backdrop-filter: blur(4px);
+      z-index: 1;
+      text-align: left;
+      font-weight: 600;
+      color: #f1f5f9;
+    }
+
+    table.timeline td,
+    table.timeline th {
+      border-right: 1px solid rgba(148, 163, 184, 0.2);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+      padding: 10px 12px;
+      min-width: 120px;
+      vertical-align: top;
+    }
+
+    table.timeline tbody tr:last-child td,
+    table.timeline tbody tr:last-child th {
+      border-bottom: none;
+    }
+
+    table.timeline td:last-child,
+    table.timeline th:last-child {
+      border-right: none;
+    }
+
+    .day-label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      align-items: center;
+      font-size: 12px;
+    }
+
+    .day-label .date {
+      font-size: 15px;
+      font-weight: 600;
+    }
+
+    .day-label .weekday {
+      color: var(--muted);
+    }
+
+    .task-chip {
+      display: block;
+      padding: 8px 10px;
+      border-radius: 10px;
+      margin-bottom: 8px;
+      background: rgba(148, 163, 184, 0.15);
+      border-left: 4px solid rgba(148, 163, 184, 0.45);
+      box-shadow: 0 8px 18px rgba(8, 15, 40, 0.35);
+    }
+
+    .task-chip:last-child {
+      margin-bottom: 0;
+    }
+
+    .task-title {
+      font-weight: 600;
+      color: #f8fafc;
+      margin-bottom: 4px;
+    }
+
+    .task-meta {
+      font-size: 11px;
+      color: var(--muted);
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .task-chip.status-未着手 {
+      background: rgba(248, 113, 113, 0.15);
+      border-left-color: rgba(248, 113, 113, 0.75);
+    }
+
+    .task-chip.status-進行中 {
+      background: rgba(14, 165, 233, 0.15);
+      border-left-color: rgba(14, 165, 233, 0.7);
+    }
+
+    .task-chip.status-完了 {
+      background: rgba(34, 197, 94, 0.18);
+      border-left-color: rgba(34, 197, 94, 0.7);
+    }
+
+    .task-chip.status-保留 {
+      background: rgba(250, 204, 21, 0.18);
+      border-left-color: rgba(250, 204, 21, 0.7);
+    }
+
+    .task-chip.status-other {
+      background: rgba(129, 140, 248, 0.18);
+      border-left-color: rgba(129, 140, 248, 0.65);
+    }
+
+    .empty-cell {
+      color: rgba(148, 163, 184, 0.5);
+      font-size: 12px;
+      text-align: center;
+    }
+
+    .legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.6);
+    }
+
+    .legend-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: rgba(148, 163, 184, 0.6);
+    }
+
+    .message {
+      text-align: center;
+      color: var(--muted);
+      padding: 24px 0;
+    }
+
+    @media (max-width: 720px) {
+      .controls {
+        gap: 12px;
+      }
+
+      .controls .field {
+        min-width: 140px;
+      }
+
+      table.timeline td,
+      table.timeline th {
+        min-width: 100px;
+        padding: 8px 10px;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="toolbar">
+    <div class="title">担当者タイムライン</div>
+    <div class="toolbar-spacer"></div>
+    <a href="index.html" class="btn btn-ghost">カンバン表示へ</a>
+  </div>
+
+  <main class="page">
+    <section class="panel">
+      <h2 style="margin-top:0; margin-bottom:14px; font-size:16px;">表示期間</h2>
+      <div class="controls">
+        <div class="field">
+          <label for="date-from">開始日</label>
+          <input id="date-from" type="date" />
+        </div>
+        <div class="field">
+          <label for="date-to">終了日</label>
+          <input id="date-to" type="date" />
+        </div>
+        <button id="btn-apply" class="btn btn-primary">表示を更新</button>
+        <div class="quick">
+          <button data-shift="-7">◀ 前週</button>
+          <button data-range="this-week">今週</button>
+          <button data-shift="7">翌週 ▶</button>
+        </div>
+      </div>
+      <p id="summary" class="summary" style="margin-top:14px;"></p>
+    </section>
+
+    <section class="panel" style="display:flex; flex-direction:column; gap:16px;">
+      <div class="legend" id="legend"></div>
+      <div class="timeline-wrapper" id="timeline-wrapper">
+        <div class="message">読み込み中...</div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    let api;
+    let RUN_MODE = 'mock';
+    let TASKS = [];
+    let STATUSES = [];
+
+    window.addEventListener('pywebviewready', async () => {
+      try {
+        api = window.pywebview.api;
+        RUN_MODE = 'pywebview';
+        await init(true);
+      } catch (err) {
+        console.error('pywebviewready failed', err);
+      }
+    });
+
+    document.addEventListener('DOMContentLoaded', async () => {
+      api = window.pywebview?.api || createMockApi();
+      if (window.pywebview?.api) RUN_MODE = 'pywebview';
+      await init(true);
+      wireControls();
+    });
+
+    function createMockApi() {
+      const today = new Date();
+      const format = d => d.toISOString().slice(0, 10);
+      return {
+        async get_tasks() {
+          const sample = [];
+          for (let i = 0; i < 6; i++) {
+            const due = new Date(today);
+            due.setDate(today.getDate() + i * 2);
+            sample.push({
+              No: i + 1,
+              ステータス: ['未着手', '進行中', '完了'][i % 3],
+              タスク: `サンプルタスク ${i + 1}`,
+              担当者: ['田中', '佐藤', '鈴木'][i % 3],
+              期限: format(due),
+              備考: 'モックデータ'
+            });
+          }
+          return sample;
+        },
+        async get_statuses() {
+          return ['未着手', '進行中', '完了', '保留'];
+        }
+      };
+    }
+
+    async function init(force = false) {
+      if (!api) return;
+      if (force) {
+        try {
+          if (RUN_MODE === 'pywebview' && typeof api.reload_from_excel === 'function') {
+            const result = await api.reload_from_excel();
+            TASKS = result?.tasks || await api.get_tasks();
+            STATUSES = result?.statuses || await api.get_statuses?.() || [];
+          } else {
+            STATUSES = typeof api.get_statuses === 'function' ? await api.get_statuses() : [];
+            TASKS = await api.get_tasks();
+          }
+        } catch (err) {
+          console.error('init failed', err);
+          TASKS = [];
+        }
+      }
+
+      ensureRangeDefaults();
+      renderSummary();
+      renderLegend();
+      renderTimeline();
+    }
+
+    function ensureRangeDefaults() {
+      const inputFrom = document.getElementById('date-from');
+      const inputTo = document.getElementById('date-to');
+      if (inputFrom.value && inputTo.value) return;
+
+      const validDueDates = TASKS.map(t => parseISO(t.期限)).filter(Boolean).sort((a, b) => a - b);
+      let start;
+      let end;
+      if (validDueDates.length >= 1) {
+        start = new Date(validDueDates[0]);
+        end = new Date(validDueDates[validDueDates.length - 1]);
+      } else {
+        const today = new Date();
+        start = startOfWeek(today);
+        end = new Date(start);
+        end.setDate(end.getDate() + 13);
+      }
+
+      // guard against overly wide ranges
+      if ((end - start) / (1000 * 60 * 60 * 24) > 60) {
+        end = new Date(start);
+        end.setDate(start.getDate() + 30);
+      }
+
+      inputFrom.value = toISODate(start);
+      inputTo.value = toISODate(end);
+    }
+
+    function wireControls() {
+      document.getElementById('btn-apply').addEventListener('click', () => {
+        renderSummary();
+        renderTimeline();
+      });
+
+      document.querySelectorAll('.quick button[data-shift]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const delta = Number(btn.dataset.shift || '0');
+          shiftRange(delta);
+          renderSummary();
+          renderTimeline();
+        });
+      });
+
+      const btnThisWeek = document.querySelector('.quick button[data-range="this-week"]');
+      btnThisWeek.addEventListener('click', () => {
+        const today = new Date();
+        const start = startOfWeek(today);
+        const end = new Date(start);
+        end.setDate(start.getDate() + 6);
+        setRange(start, end);
+        renderSummary();
+        renderTimeline();
+      });
+    }
+
+    function shiftRange(deltaDays) {
+      const fromInput = document.getElementById('date-from');
+      const toInput = document.getElementById('date-to');
+      const from = parseISO(fromInput.value);
+      const to = parseISO(toInput.value);
+      if (!from || !to) return;
+      from.setDate(from.getDate() + deltaDays);
+      to.setDate(to.getDate() + deltaDays);
+      setRange(from, to);
+    }
+
+    function setRange(from, to) {
+      const inputFrom = document.getElementById('date-from');
+      const inputTo = document.getElementById('date-to');
+      inputFrom.value = toISODate(from);
+      inputTo.value = toISODate(to);
+    }
+
+    function renderSummary() {
+      const from = parseISO(document.getElementById('date-from').value);
+      const to = parseISO(document.getElementById('date-to').value);
+      const summary = document.getElementById('summary');
+      if (!from || !to) {
+        summary.textContent = '開始日と終了日を指定してください。';
+        return;
+      }
+      const diff = Math.round((to - from) / (1000 * 60 * 60 * 24)) + 1;
+      const inRange = TASKS.filter(t => {
+        const due = parseISO(t.期限);
+        return due && due >= from && due <= to;
+      }).length;
+      const withoutDue = TASKS.filter(t => !parseISO(t.期限)).length;
+      summary.textContent = `表示期間: ${toLocale(from)} 〜 ${toLocale(to)} （${diff}日間） / 対象タスク ${inRange} 件、期限未設定 ${withoutDue} 件`;
+    }
+
+    function renderLegend() {
+      const legend = document.getElementById('legend');
+      legend.innerHTML = '';
+      const baseStatuses = Array.isArray(STATUSES) && STATUSES.length
+        ? STATUSES
+        : Array.from(new Set(TASKS.map(t => t.ステータス).filter(Boolean)));
+      const seen = new Set();
+      baseStatuses.forEach(name => {
+        const dot = document.createElement('span');
+        dot.className = 'legend-dot';
+        dot.style.background = statusColor(name);
+        const item = document.createElement('span');
+        item.className = 'legend-item';
+        item.appendChild(dot);
+        const label = document.createElement('span');
+        label.textContent = name;
+        item.appendChild(label);
+        legend.appendChild(item);
+        seen.add(name);
+      });
+
+      const hasOther = TASKS.some(t => t.ステータス && !seen.has(t.ステータス));
+      if (hasOther) {
+        const dot = document.createElement('span');
+        dot.className = 'legend-dot';
+        dot.style.background = statusColor('other');
+        const item = document.createElement('span');
+        item.className = 'legend-item';
+        item.appendChild(dot);
+        const label = document.createElement('span');
+        label.textContent = 'その他';
+        item.appendChild(label);
+        legend.appendChild(item);
+      }
+    }
+
+    function renderTimeline() {
+      const wrapper = document.getElementById('timeline-wrapper');
+      const from = parseISO(document.getElementById('date-from').value);
+      const to = parseISO(document.getElementById('date-to').value);
+      if (!from || !to || from > to) {
+        wrapper.innerHTML = '<div class="message">期間の指定が正しくありません。</div>';
+        return;
+      }
+
+      const days = enumerateDays(from, to);
+      if (!days.length) {
+        wrapper.innerHTML = '<div class="message">表示できる日付がありません。</div>';
+        return;
+      }
+
+      const assignees = collectAssignees(from, to);
+      if (!assignees.length) {
+        wrapper.innerHTML = '<div class="message">表示できるタスクがありません。</div>';
+        return;
+      }
+
+      const table = document.createElement('table');
+      table.className = 'timeline';
+
+      const thead = document.createElement('thead');
+      const trHead = document.createElement('tr');
+      const thCorner = document.createElement('th');
+      thCorner.textContent = '担当者';
+      trHead.appendChild(thCorner);
+      days.forEach(day => {
+        const th = document.createElement('th');
+        const label = document.createElement('div');
+        label.className = 'day-label';
+        const dateSpan = document.createElement('span');
+        dateSpan.className = 'date';
+        dateSpan.textContent = `${day.month}/${day.date}`;
+        const weekdaySpan = document.createElement('span');
+        weekdaySpan.className = 'weekday';
+        weekdaySpan.textContent = day.weekday;
+        label.appendChild(dateSpan);
+        label.appendChild(weekdaySpan);
+        th.appendChild(label);
+        trHead.appendChild(th);
+      });
+      thead.appendChild(trHead);
+      table.appendChild(thead);
+
+      const tbody = document.createElement('tbody');
+      const taskMap = buildTaskLookup(from, to);
+
+      assignees.forEach(name => {
+        const tr = document.createElement('tr');
+        const th = document.createElement('th');
+        th.textContent = name;
+        tr.appendChild(th);
+
+        days.forEach(day => {
+          const td = document.createElement('td');
+          const key = day.iso;
+          const items = (taskMap.get(name)?.get(key)) || [];
+          if (!items.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-cell';
+            empty.textContent = '-';
+            td.appendChild(empty);
+          } else {
+            items.forEach(task => {
+              td.appendChild(renderTaskChip(task));
+            });
+          }
+          tr.appendChild(td);
+        });
+        tbody.appendChild(tr);
+      });
+
+      table.appendChild(tbody);
+
+      wrapper.innerHTML = '';
+      wrapper.appendChild(table);
+    }
+
+    function renderTaskChip(task) {
+      const div = document.createElement('div');
+      div.className = 'task-chip';
+      if (task.ステータス) {
+        const rawClass = `status-${task.ステータス}`;
+        div.classList.add(rawClass);
+        div.classList.add(sanitizeClass(rawClass));
+      } else {
+        div.classList.add('status-other');
+      }
+
+      const title = document.createElement('div');
+      title.className = 'task-title';
+      title.textContent = task.タスク || '(タイトルなし)';
+      div.appendChild(title);
+
+      const meta = document.createElement('div');
+      meta.className = 'task-meta';
+      if (task.ステータス) {
+        const status = document.createElement('span');
+        status.textContent = `ステータス: ${task.ステータス}`;
+        meta.appendChild(status);
+      }
+      if (task.No) {
+        const no = document.createElement('span');
+        no.textContent = `No.${task.No}`;
+        meta.appendChild(no);
+      }
+      if (task.備考) {
+        const notes = document.createElement('span');
+        notes.textContent = task.備考;
+        meta.appendChild(notes);
+      }
+      div.appendChild(meta);
+      return div;
+    }
+
+    function buildTaskLookup(from, to) {
+      const map = new Map();
+      TASKS.forEach(task => {
+        const due = parseISO(task.期限);
+        if (!due || due < from || due > to) return;
+        const assignee = task.担当者?.trim() || '（担当者未設定）';
+        if (!map.has(assignee)) map.set(assignee, new Map());
+        const byDate = map.get(assignee);
+        const key = toISODate(due);
+        if (!byDate.has(key)) byDate.set(key, []);
+        byDate.get(key).push(task);
+      });
+
+      // sort each bucket by No -> title
+      map.forEach(byDate => {
+        byDate.forEach(list => {
+          list.sort((a, b) => {
+            if (a.No && b.No && a.No !== b.No) return a.No - b.No;
+            return (a.タスク || '').localeCompare(b.タスク || '');
+          });
+        });
+      });
+      return map;
+    }
+
+    function collectAssignees(rangeFrom, rangeTo) {
+      const assignees = new Set();
+      TASKS.forEach(task => {
+        const due = parseISO(task.期限);
+        if (!due) return;
+        if (!rangeFrom || !rangeTo || due < rangeFrom || due > rangeTo) return;
+        assignees.add(task.担当者?.trim() || '（担当者未設定）');
+      });
+      return Array.from(assignees).sort((a, b) => a.localeCompare(b, 'ja'));
+    }
+
+    function enumerateDays(from, to) {
+      const days = [];
+      const names = ['日', '月', '火', '水', '木', '金', '土'];
+      const cursor = new Date(from);
+      while (cursor <= to) {
+        days.push({
+          iso: toISODate(cursor),
+          month: cursor.getMonth() + 1,
+          date: cursor.getDate(),
+          weekday: `${names[cursor.getDay()]}曜`
+        });
+        cursor.setDate(cursor.getDate() + 1);
+      }
+      return days;
+    }
+
+    function parseISO(value) {
+      if (!value) return null;
+      const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+      if (!m) return null;
+      const dt = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+      return isNaN(dt.getTime()) ? null : dt;
+    }
+
+    function toISODate(date) {
+      const tzOffset = date.getTimezoneOffset() * 60000;
+      return new Date(date.getTime() - tzOffset).toISOString().slice(0, 10);
+    }
+
+    function toLocale(date) {
+      return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
+    }
+
+    function startOfWeek(date) {
+      const start = new Date(date);
+      start.setDate(date.getDate() - date.getDay());
+      start.setHours(0, 0, 0, 0);
+      return start;
+    }
+
+    function statusColor(name) {
+      switch (name) {
+        case '未着手':
+          return 'rgba(248, 113, 113, 0.8)';
+        case '進行中':
+          return 'rgba(56, 189, 248, 0.8)';
+        case '完了':
+          return 'rgba(34, 197, 94, 0.8)';
+        case '保留':
+          return 'rgba(250, 204, 21, 0.8)';
+        default:
+          return 'rgba(129, 140, 248, 0.8)';
+      }
+    }
+
+    function sanitizeClass(value) {
+      return value.replace(/[^\w-]/g, '-');
+    }
+
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `timeline.html` page to visualize tasks per assignee in a calendar-style grid
- include configurable date range controls, quick navigation buttons, and a status legend for clarity
- provide mock data fallback so the page can be previewed outside of pywebview

## Testing
- not run (UI only)


------
https://chatgpt.com/codex/tasks/task_e_68fb9b6d5e3c8322a4e017d896802e01