### PR TITLE
Expand drop target area for empty kanban columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,13 +145,20 @@
       display: flex;
       flex-direction: column;
       min-height: 150px;
+      flex: 1;
     }
 
     .dropzone {
       border: 2px dashed transparent;
       border-radius: 12px;
-      padding: 4px;
+      padding: 12px;
+      min-height: 180px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
       transition: border-color .15s ease, background .15s ease;
+      box-sizing: border-box;
+      flex: 1;
     }
 
     .dropzone.dragover {


### PR DESCRIPTION
## Summary
- expand the kanban column drop zones so they remain large even when no cards are present
- ensure the drop zone flexes to fill the column and keeps consistent spacing between cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb9fdfafac8322ae250e00a2c271d6