### PR TITLE
Support hierarchical categories on kanban and list views

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -28,6 +28,8 @@ except ImportError:  # pragma: no cover - optional dependency guard
 
 TASK_COLUMNS = [
     "ステータス",
+    "大分類",
+    "中分類",
     "タスク",
     "担当者",
     "優先度",
@@ -328,6 +330,8 @@ class TaskStore:
         return {
             "No": int(idx + 1),
             "ステータス": "" if pd.isna(row["ステータス"]) else str(row["ステータス"]),
+            "大分類": "" if pd.isna(row["大分類"]) else str(row["大分類"]),
+            "中分類": "" if pd.isna(row["中分類"]) else str(row["中分類"]),
             "タスク": "" if pd.isna(row["タスク"]) else str(row["タスク"]),
             "担当者": "" if pd.isna(row["担当者"]) else str(row["担当者"]),
             "優先度": _format_priority(row["優先度"]),
@@ -354,6 +358,8 @@ class TaskStore:
             task = dict(payload)
 
             status = str(task.get("ステータス", "") or "").strip()
+            major = str(task.get("大分類", "") or "").strip()
+            minor = str(task.get("中分類", "") or "").strip()
             title = str(task.get("タスク", "") or "").strip()
             assignee = str(task.get("担当者", "") or "").strip()
             notes = str(task.get("備考", "") or "")
@@ -362,6 +368,8 @@ class TaskStore:
 
             row = {
                 "ステータス": status,
+                "大分類": major,
+                "中分類": minor,
                 "タスク": title,
                 "担当者": assignee,
                 "優先度": priority,
@@ -382,6 +390,10 @@ class TaskStore:
                 status = str(patch["ステータス"] or "").strip()
                 self._ensure_status_registered(status)
                 self._df.at[row_index, "ステータス"] = status
+            if "大分類" in patch:
+                self._df.at[row_index, "大分類"] = str(patch["大分類"] or "").strip()
+            if "中分類" in patch:
+                self._df.at[row_index, "中分類"] = str(patch["中分類"] or "").strip()
             if "タスク" in patch:
                 self._df.at[row_index, "タスク"] = str(patch["タスク"] or "").strip()
             if "担当者" in patch:

--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -195,6 +195,25 @@
       font-weight: 600;
     }
 
+    .card-category {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-bottom: 6px;
+    }
+
+    .badge-major {
+      color: #bfdbfe;
+      background: rgba(59, 130, 246, 0.18);
+      border-color: rgba(59, 130, 246, 0.35);
+    }
+
+    .badge-minor {
+      color: #bbf7d0;
+      background: rgba(16, 185, 129, 0.18);
+      border-color: rgba(16, 185, 129, 0.35);
+    }
+
     .badge {
       font-size: 11px;
       padding: 3px 8px;
@@ -515,6 +534,20 @@
       </select>
     </div>
 
+    <div class="filter">
+      <label for="flt-major">大分類</label>
+      <select id="flt-major">
+        <option value="__CATEGORY_ALL__">（すべて）</option>
+      </select>
+    </div>
+
+    <div class="filter">
+      <label for="flt-minor">中分類</label>
+      <select id="flt-minor" disabled>
+        <option value="__CATEGORY_MINOR_ALL__">（すべて）</option>
+      </select>
+    </div>
+
     <div class="filter" style="min-width:260px;flex:1;">
       <label>ステータス</label>
       <div class="status-checks" id="flt-statuses"></div>
@@ -580,6 +613,14 @@
         <div class="row">
           <label for="f-status">ステータス</label>
           <select id="f-status"></select>
+        </div>
+        <div class="row">
+          <label for="f-major">大分類</label>
+          <input type="text" id="f-major" />
+        </div>
+        <div class="row">
+          <label for="f-minor">中分類</label>
+          <input type="text" id="f-minor" />
         </div>
         <div class="row">
           <label for="f-priority">優先度</label>

--- a/frontend/pages/list.html
+++ b/frontend/pages/list.html
@@ -270,6 +270,28 @@
       font-size: 12px;
     }
 
+    .category-pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 3px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(148, 163, 184, 0.12);
+    }
+
+    .category-major {
+      background: rgba(59, 130, 246, 0.18);
+      border-color: rgba(59, 130, 246, 0.4);
+      color: #bfdbfe;
+    }
+
+    .category-minor {
+      background: rgba(16, 185, 129, 0.18);
+      border-color: rgba(16, 185, 129, 0.35);
+      color: #bbf7d0;
+    }
+
     .priority-pill {
       display: inline-flex;
       align-items: center;
@@ -478,6 +500,20 @@
       </select>
     </div>
 
+    <div class="filter">
+      <label for="flt-major">大分類</label>
+      <select id="flt-major">
+        <option value="__CATEGORY_ALL__">（すべて）</option>
+      </select>
+    </div>
+
+    <div class="filter">
+      <label for="flt-minor">中分類</label>
+      <select id="flt-minor" disabled>
+        <option value="__CATEGORY_MINOR_ALL__">（すべて）</option>
+      </select>
+    </div>
+
     <div class="filter" style="min-width:260px;flex:1;">
       <label>ステータス</label>
       <div class="status-checks" id="flt-statuses"></div>
@@ -547,6 +583,14 @@
         <div class="row">
           <label for="f-status">ステータス</label>
           <select id="f-status"></select>
+        </div>
+        <div class="row">
+          <label for="f-major">大分類</label>
+          <input type="text" id="f-major" />
+        </div>
+        <div class="row">
+          <label for="f-minor">中分類</label>
+          <input type="text" id="f-minor" />
         </div>
         <div class="row">
           <label for="f-priority">優先度</label>

--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -9,13 +9,19 @@ function createMockApi() {
   const pad = n => String(n).padStart(2, '0');
   const toISO = date => `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
   const today = new Date();
+  const majorCategories = ['プロジェクトA', 'プロジェクトB', 'プロジェクトC'];
+  const minorCategories = ['企画', '設計', '実装', '検証'];
   const sampleTasks = Array.from({ length: 8 }).map((_, idx) => {
     const due = new Date(today);
     due.setDate(today.getDate() + idx - 2);
     const status = baseStatuses[idx % baseStatuses.length];
     statusSet.add(status);
+    const major = majorCategories[idx % majorCategories.length];
+    const minor = minorCategories[idx % minorCategories.length];
     return {
       ステータス: status,
+      大分類: major,
+      中分類: minor,
       タスク: `サンプルタスク ${idx + 1}`,
       担当者: ['田中', '佐藤', '鈴木', '高橋'][idx % 4],
       優先度: ['高', '中', '低'][idx % 3],
@@ -24,7 +30,11 @@ function createMockApi() {
     };
   });
   const tasks = [...sampleTasks];
-  let validations = { 'ステータス': Array.from(statusSet) };
+  let validations = {
+    'ステータス': Array.from(statusSet),
+    '大分類': Array.from(new Set(majorCategories)),
+    '中分類': Array.from(new Set(minorCategories))
+  };
 
   const cloneTask = task => ({ ...task });
 
@@ -51,8 +61,13 @@ function createMockApi() {
     const status = sanitizeStatus(payload?.ステータス);
     statusSet.add(status);
 
+    const major = String(payload?.大分類 ?? '').trim();
+    const minor = String(payload?.中分類 ?? '').trim();
+
     return {
       ステータス: status,
+      大分類: major,
+      中分類: minor,
       タスク: String(payload?.タスク ?? '').trim(),
       担当者: String(payload?.担当者 ?? '').trim(),
       優先度: normalizePriority(payload?.優先度),
@@ -179,17 +194,20 @@ ready(async () => {
 });
 
 /* ===================== 状態 ===================== */
-const VALIDATION_COLUMNS = ["ステータス", "タスク", "担当者", "優先度", "期限", "備考"];
+const VALIDATION_COLUMNS = ["ステータス", "大分類", "中分類", "タスク", "担当者", "優先度", "期限", "備考"];
 const DEFAULT_STATUSES = ['未着手', '進行中', '完了', '保留'];
 const ASSIGNEE_FILTER_ALL = '__ALL__';
 const ASSIGNEE_FILTER_UNASSIGNED = '__UNASSIGNED__';
 const ASSIGNEE_UNASSIGNED_LABEL = '（未割り当て）';
+const CATEGORY_FILTER_ALL = '__CATEGORY_ALL__';
+const CATEGORY_FILTER_MINOR_ALL = '__CATEGORY_MINOR_ALL__';
 let STATUSES = [];
 let FILTERS = {
   assignee: ASSIGNEE_FILTER_ALL,
   statuses: new Set(),              // 初期化時に全ONにする
   keyword: '',
-  date: { mode: 'none', from: '', to: '' }
+  date: { mode: 'none', from: '', to: '' },
+  category: { major: CATEGORY_FILTER_ALL, minor: CATEGORY_FILTER_MINOR_ALL }
 };
 let TASKS = [];
 let CURRENT_EDIT = null;
@@ -397,8 +415,10 @@ function renderList() {
   thead.innerHTML = `
     <tr>
       <th style="width:70px;">No</th>
-      <th style="width:160px;">ステータス</th>
+      <th style="width:160px;">大分類</th>
+      <th style="width:160px;">中分類</th>
       <th>タスク</th>
+      <th style="width:160px;">ステータス</th>
       <th style="width:160px;">担当者</th>
       <th style="width:140px;">優先度</th>
       <th style="width:160px;">期限</th>
@@ -428,16 +448,34 @@ function renderList() {
       noTd.textContent = task.No ? `#${task.No}` : '';
       tr.appendChild(noTd);
 
+      const majorTd = document.createElement('td');
+      if ((task.大分類 || '').trim()) {
+        const badge = document.createElement('span');
+        badge.className = 'category-pill category-major';
+        badge.textContent = task.大分類.trim();
+        majorTd.appendChild(badge);
+      }
+      tr.appendChild(majorTd);
+
+      const minorTd = document.createElement('td');
+      if ((task.中分類 || '').trim()) {
+        const badge = document.createElement('span');
+        badge.className = 'category-pill category-minor';
+        badge.textContent = task.中分類.trim();
+        minorTd.appendChild(badge);
+      }
+      tr.appendChild(minorTd);
+
+      const titleTd = document.createElement('td');
+      titleTd.textContent = task.タスク || '(無題)';
+      tr.appendChild(titleTd);
+
       const statusTd = document.createElement('td');
       const statusPill = document.createElement('span');
       statusPill.className = 'status-pill';
       statusPill.textContent = task.ステータス || '';
       statusTd.appendChild(statusPill);
       tr.appendChild(statusTd);
-
-      const titleTd = document.createElement('td');
-      titleTd.textContent = task.タスク || '(無題)';
-      tr.appendChild(titleTd);
 
       const assigneeTd = document.createElement('td');
       assigneeTd.textContent = (task.担当者 || '').trim();
@@ -489,6 +527,30 @@ function uniqAssignees() {
   return Array.from(set).sort((a, b) => a.localeCompare(b, 'ja'));
 }
 
+function collectCategoryOptions() {
+  const majorMap = new Map();
+  TASKS.forEach(task => {
+    const major = String(task?.大分類 ?? '').trim();
+    const minor = String(task?.中分類 ?? '').trim();
+    if (!major) return;
+    if (!majorMap.has(major)) {
+      majorMap.set(major, new Set());
+    }
+    if (minor) {
+      majorMap.get(major).add(minor);
+    }
+  });
+
+  const majorList = Array.from(majorMap.keys()).sort((a, b) => a.localeCompare(b, 'ja'));
+  const minorMap = new Map();
+  majorList.forEach(major => {
+    const minors = majorMap.get(major) ?? new Set();
+    minorMap.set(major, Array.from(minors).sort((a, b) => a.localeCompare(b, 'ja')));
+  });
+
+  return { majorList, minorMap };
+}
+
 function buildFiltersUI() {
   // ステータス（チェックボックス）
   const wrap = document.getElementById('flt-statuses');
@@ -510,6 +572,67 @@ function buildFiltersUI() {
     lbl.appendChild(cb); lbl.appendChild(span);
     wrap.appendChild(lbl);
   });
+
+  // 大分類・中分類
+  const majorSel = document.getElementById('flt-major');
+  const minorSel = document.getElementById('flt-minor');
+  if (majorSel && minorSel) {
+    const { majorList, minorMap } = collectCategoryOptions();
+    let currentMajor = FILTERS.category?.major ?? CATEGORY_FILTER_ALL;
+    let currentMinor = FILTERS.category?.minor ?? CATEGORY_FILTER_MINOR_ALL;
+
+    if (!majorList.includes(currentMajor)) {
+      currentMajor = CATEGORY_FILTER_ALL;
+      FILTERS.category.major = CATEGORY_FILTER_ALL;
+    }
+
+    const majorOptions = [
+      `<option value="${CATEGORY_FILTER_ALL}">（すべて）</option>`
+    ].concat(majorList.map(name => `<option value="${name}">${name}</option>`));
+    majorSel.innerHTML = majorOptions.join('');
+    majorSel.value = currentMajor;
+
+    const renderMinorOptions = () => {
+      const majorsMinors = minorMap.get(currentMajor) || [];
+      const minorOptions = [
+        `<option value="${CATEGORY_FILTER_MINOR_ALL}">（すべて）</option>`
+      ].concat(majorsMinors.map(name => `<option value="${name}">${name}</option>`));
+      minorSel.innerHTML = minorOptions.join('');
+
+      if (currentMajor === CATEGORY_FILTER_ALL || majorsMinors.length === 0) {
+        minorSel.disabled = true;
+        currentMinor = CATEGORY_FILTER_MINOR_ALL;
+        minorSel.value = CATEGORY_FILTER_MINOR_ALL;
+        FILTERS.category.minor = CATEGORY_FILTER_MINOR_ALL;
+      } else {
+        minorSel.disabled = false;
+        if (majorsMinors.includes(currentMinor)) {
+          minorSel.value = currentMinor;
+        } else {
+          currentMinor = CATEGORY_FILTER_MINOR_ALL;
+          minorSel.value = CATEGORY_FILTER_MINOR_ALL;
+        }
+        FILTERS.category.minor = currentMinor;
+      }
+    };
+
+    renderMinorOptions();
+
+    majorSel.onchange = () => {
+      currentMajor = majorSel.value;
+      FILTERS.category.major = currentMajor;
+      currentMinor = CATEGORY_FILTER_MINOR_ALL;
+      FILTERS.category.minor = currentMinor;
+      renderMinorOptions();
+      renderList();
+    };
+
+    minorSel.onchange = () => {
+      currentMinor = minorSel.value;
+      FILTERS.category.minor = currentMinor;
+      renderList();
+    };
+  }
 
   // 担当者（セレクト）
   const sel = document.getElementById('flt-assignee');
@@ -576,7 +699,13 @@ function buildFiltersUI() {
 
   // 解除ボタン
   document.getElementById('btn-clear-filters').onclick = () => {
-    FILTERS = { assignee: ASSIGNEE_FILTER_ALL, statuses: new Set(STATUSES), keyword: '', date: { mode: 'none', from: '', to: '' } };
+    FILTERS = {
+      assignee: ASSIGNEE_FILTER_ALL,
+      statuses: new Set(STATUSES),
+      keyword: '',
+      date: { mode: 'none', from: '', to: '' },
+      category: { major: CATEGORY_FILTER_ALL, minor: CATEGORY_FILTER_MINOR_ALL }
+    };
     buildFiltersUI();
     renderList();
   };
@@ -824,8 +953,19 @@ function getFilteredTasks() {
   const statuses = FILTERS.statuses;
   const df = FILTERS.date;
   const keyword = (FILTERS.keyword || '').trim().toLowerCase();
+  const majorFilter = FILTERS.category?.major ?? CATEGORY_FILTER_ALL;
+  const minorFilter = FILTERS.category?.minor ?? CATEGORY_FILTER_MINOR_ALL;
 
   return TASKS.filter(t => {
+    if (majorFilter !== CATEGORY_FILTER_ALL) {
+      const major = String(t.大分類 ?? '').trim();
+      if (major !== majorFilter) return false;
+      if (minorFilter !== CATEGORY_FILTER_MINOR_ALL) {
+        const minor = String(t.中分類 ?? '').trim();
+        if (minor !== minorFilter) return false;
+      }
+    }
+
     // 担当者
     const who = String(t.担当者 ?? '').trim();
     if (assignee === ASSIGNEE_FILTER_UNASSIGNED) {
@@ -879,6 +1019,8 @@ function openCreate() {
   openModal({
     No: '',
     ステータス: STATUSES[0] || '未着手',
+    大分類: '',
+    中分類: '',
     タスク: '',
     担当者: '',
     優先度: '',
@@ -898,6 +1040,8 @@ function openModal(task, { mode }) {
   const title = document.getElementById('modal-title');
   const fno = document.getElementById('f-no');
   const fstat = document.getElementById('f-status');
+  const fmajor = document.getElementById('f-major');
+  const fminor = document.getElementById('f-minor');
   const fttl = document.getElementById('f-title');
   const fwho = document.getElementById('f-assignee');
   const fprio = document.getElementById('f-priority');
@@ -917,6 +1061,8 @@ function openModal(task, { mode }) {
 
   fno.value = task.No ?? '';
   fstat.value = task.ステータス || STATUSES[0] || '未着手';
+  if (fmajor) fmajor.value = task.大分類 || '';
+  if (fminor) fminor.value = task.中分類 || '';
   fttl.value = task.タスク || '';
   fwho.value = task.担当者 || '';
   fprio.value = task.優先度 !== undefined && task.優先度 !== null ? String(task.優先度) : '';
@@ -954,6 +1100,8 @@ function openModal(task, { mode }) {
     e.preventDefault();
     const payload = {
       ステータス: fstat.value.trim(),
+      大分類: fmajor ? fmajor.value.trim() : '',
+      中分類: fminor ? fminor.value.trim() : '',
       タスク: fttl.value.trim(),
       担当者: fwho.value.trim(),
       優先度: fprio.value.trim(),


### PR DESCRIPTION
## Summary
- add 大分類/中分類 columns to the backend task store so hierarchy values persist in Excel
- surface hierarchy data on the kanban and list pages, including category badges and form inputs
- add major/minor category filters alongside existing filters for both views

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ff45eaa6ac8322b63acff2af19696e