### PR TITLE
Handle unset statuses across views

### DIFF
--- a/frontend/scripts/timeline.js
+++ b/frontend/scripts/timeline.js
@@ -368,8 +368,9 @@ function renderTimeline() {
 function renderTaskChip(task) {
   const div = document.createElement('div');
   div.className = 'task-chip';
-  if (task.ステータス) {
-    const rawClass = `status-${task.ステータス}`;
+  const statusText = String(task.ステータス ?? '').trim();
+  if (statusText) {
+    const rawClass = `status-${statusText}`;
     div.classList.add(rawClass);
     div.classList.add(sanitizeClass(rawClass));
   } else {
@@ -383,11 +384,9 @@ function renderTaskChip(task) {
 
   const meta = document.createElement('div');
   meta.className = 'task-meta';
-  if (task.ステータス) {
-    const status = document.createElement('span');
-    status.textContent = `ステータス: ${task.ステータス}`;
-    meta.appendChild(status);
-  }
+  const status = document.createElement('span');
+  status.textContent = `ステータス: ${statusText || '未設定'}`;
+  meta.appendChild(status);
   if (task.No) {
     const no = document.createElement('span');
     no.textContent = `No.${task.No}`;


### PR DESCRIPTION
## Summary
- add a shared "ステータス未設定" label and normalization so kanban filters, counts, and DnD handle tasks without statuses
- include the unset-status option in the list view filtering/sorting pipeline and map it back to empty values when saving
- align the timeline chip display to show "ステータス: 未設定" for tasks without a status

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff6733a8608322b73dadb52d3ababe