### PR TITLE
Fix timeline initialization error caused by stray mock API snippet

### DIFF
--- a/frontend/scripts/timeline.js
+++ b/frontend/scripts/timeline.js
@@ -51,29 +51,6 @@ setupRuntime({
 ready(() => {
   wireControls();
 });
-      if (!located) throw new Error('指定したタスクが見つかりません');
-      const updated = normalizeTask({ ...located.record, ...payload });
-      tasks[located.index] = updated;
-      return { ...cloneTask(updated), No: located.index + 1 };
-    },
-    async delete_task(no) {
-      const located = locateTask(no);
-      if (!located) return false;
-      tasks.splice(located.index, 1);
-      return true;
-    },
-    async reload_from_excel() {
-      return {
-        tasks: withSequentialNo(),
-        statuses: Array.from(statusSet),
-        validations: { ...validations }
-      };
-    },
-    async save_excel() {
-      return 'mock-data.xlsx';
-    }
-  };
-}
 
 async function init(force = false) {
   if (!api) return;


### PR DESCRIPTION
## Summary
- remove an accidental mock API snippet from the timeline script that prevented initialization
- allow the page to finish setting the date range and render the timeline normally

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff8dc4163c83229f8ce055c3bafb1e