### PR TITLE
Adjust list page layout to keep scrollbars visible

### DIFF
--- a/frontend/styles/list.css
+++ b/frontend/styles/list.css
@@ -1,3 +1,15 @@
+body.page-list {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-list .filters-bar,
+.page-list .list-summary,
+.page-list .footer-hint {
+  flex-shrink: 0;
+}
+
 .list-summary {
   padding: 14px 18px 0;
   font-size: 13px;
@@ -5,7 +17,10 @@
 }
 
 .list-wrapper {
+  flex: 1;
+  display: flex;
   padding: 0 18px 18px;
+  min-height: 0;
 }
 
 .list-panel {
@@ -13,8 +28,9 @@
   border-radius: 18px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
-  overflow-x: auto;
-  overflow-y: hidden;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
 }
 
 table.task-list {


### PR DESCRIPTION
## Summary
- turn the list page into a flex column layout so the list section fills the viewport height
- allow the list panel to scroll both vertically and horizontally within its frame, keeping the horizontal scrollbar visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69003c7b070483229b478d733dea869c