### PR TITLE
Add backlog view to timeline page

### DIFF
--- a/frontend/pages/timeline.html
+++ b/frontend/pages/timeline.html
@@ -53,6 +53,18 @@
         <div class="message">読み込み中...</div>
       </div>
     </section>
+
+    <section class="panel backlog-panel" id="timeline-backlog">
+      <div class="backlog-header">
+        <h2 class="backlog-title">バックログ</h2>
+        <p class="backlog-description">
+          期限未設定や表示期間外のタスクを表示しています。ダブルクリックで編集できます。
+        </p>
+      </div>
+      <div class="backlog-content" id="backlog-content">
+        <div class="message">読み込み中...</div>
+      </div>
+    </section>
   </main>
 
   <div id="modal" class="modal" role="dialog" aria-modal="true" aria-hidden="true">

--- a/frontend/styles/timeline.css
+++ b/frontend/styles/timeline.css
@@ -79,6 +79,110 @@ main.page {
   margin-top: 14px;
 }
 
+.backlog-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.backlog-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.backlog-title {
+  margin: 0;
+  font-size: 16px;
+  color: #e2e8f0;
+}
+
+.backlog-description {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.backlog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.7);
+  padding: 18px;
+}
+
+.backlog-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.backlog-group:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.backlog-group-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.backlog-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.backlog-item {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: rgba(30, 41, 59, 0.65);
+  box-shadow: 0 8px 18px rgba(8, 15, 40, 0.28);
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.backlog-item:hover {
+  border-color: rgba(129, 140, 248, 0.6);
+  transform: translateY(-1px);
+}
+
+.backlog-item-title {
+  font-weight: 600;
+  color: #f8fafc;
+  margin-bottom: 6px;
+}
+
+.backlog-item-meta {
+  font-size: 11px;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.backlog-empty {
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+#timeline-backlog .message {
+  text-align: center;
+  color: var(--muted);
+}
+
 .timeline-wrapper {
   overflow: auto;
   border-radius: 16px;


### PR DESCRIPTION
## Summary
- add a backlog section to the timeline page so undated and out-of-range tasks remain visible
- extend the timeline renderer to collect backlog tasks, show them grouped by assignee, and update the summary counts
- style the backlog panel to match the existing timeline presentation

## Testing
- not run (front-end only)


------
https://chatgpt.com/codex/tasks/task_e_6900ab5ef114832290b328e0da09c6bf