### PR TITLE
Add toggle to collapse filters on task list page

### DIFF
--- a/frontend/pages/list.html
+++ b/frontend/pages/list.html
@@ -27,6 +27,17 @@
     <a href="timeline.html" class="btn btn-ghost">タイムライン</a>
   </div>
 
+  <div class="filters-toggle-row">
+    <button
+      type="button"
+      id="btn-toggle-filters"
+      class="btn btn-ghost filters-toggle"
+      aria-expanded="true"
+      aria-controls="filters-bar"
+      data-expanded="true"
+    >フィルター設定を隠す</button>
+  </div>
+
   <div class="filters-bar" id="filters-bar">
     <div class="filter">
       <label for="flt-assignee">担当者</label>

--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -18,6 +18,11 @@ const {
 let api;                  // 実際に使う API （後で差し替える）
 let RUN_MODE = 'mock';    // 'mock' | 'pywebview'
 let WIRED = false;        // ツールバー多重バインド防止
+let FILTER_TOGGLE_WIRED = false;
+
+const FILTERS_COLLAPSED_STORAGE_KEY = 'taskList.filtersCollapsed';
+let FILTERS_COLLAPSED = loadFiltersCollapsed();
+applyFilterCollapsedState();
 
 setupRuntime({
   mockApiFactory: createMockApi,
@@ -148,6 +153,49 @@ function saveColumnWidths() {
     window.localStorage?.setItem(COLUMN_WIDTH_STORAGE_KEY, JSON.stringify(COLUMN_WIDTHS || {}));
   } catch (err) {
     console.warn('[list] failed to save column widths', err);
+  }
+}
+
+function loadFiltersCollapsed() {
+  try {
+    const raw = window.localStorage?.getItem(FILTERS_COLLAPSED_STORAGE_KEY);
+    if (!raw) return false;
+    return raw === '1' || raw === 'true';
+  } catch (err) {
+    console.warn('[list] failed to load filter toggle state', err);
+    return false;
+  }
+}
+
+function saveFiltersCollapsed(value) {
+  try {
+    if (value) {
+      window.localStorage?.setItem(FILTERS_COLLAPSED_STORAGE_KEY, '1');
+    } else {
+      window.localStorage?.setItem(FILTERS_COLLAPSED_STORAGE_KEY, '0');
+    }
+  } catch (err) {
+    console.warn('[list] failed to save filter toggle state', err);
+  }
+}
+
+function applyFilterCollapsedState() {
+  const collapsed = !!FILTERS_COLLAPSED;
+  const body = document.body;
+  if (body) {
+    body.classList.toggle('filters-collapsed', collapsed);
+  }
+  const filtersBar = document.getElementById('filters-bar');
+  if (filtersBar) {
+    filtersBar.hidden = collapsed;
+    filtersBar.setAttribute('aria-hidden', collapsed ? 'true' : 'false');
+  }
+  const toggle = document.getElementById('btn-toggle-filters');
+  if (toggle) {
+    const expanded = collapsed ? 'false' : 'true';
+    toggle.setAttribute('aria-expanded', expanded);
+    toggle.dataset.expanded = expanded;
+    toggle.textContent = collapsed ? 'フィルター設定を表示' : 'フィルター設定を隠す';
   }
 }
 
@@ -619,6 +667,7 @@ async function init(force = false) {
   await applyStateFromPayload(payload, { preserveFilters: true, fallbackToApi: true });
   // 初回＆再読込時にフィルタUIを最新へ
   if (!WIRED) { wireToolbar(); WIRED = true; }
+  wireFilterToggle();
 }
 
 /* ===================== レンダリング ===================== */
@@ -1098,6 +1147,8 @@ function buildFiltersUI() {
     buildFiltersUI();
     renderList();
   };
+
+  applyFilterCollapsedState();
 }
 
 
@@ -1176,6 +1227,20 @@ function updateDueIndicators(tasks) {
 }
 
 /* ===================== ツールバー ===================== */
+function wireFilterToggle() {
+  const toggle = document.getElementById('btn-toggle-filters');
+  if (!toggle) return;
+  if (!FILTER_TOGGLE_WIRED) {
+    toggle.addEventListener('click', () => {
+      FILTERS_COLLAPSED = !FILTERS_COLLAPSED;
+      saveFiltersCollapsed(FILTERS_COLLAPSED);
+      applyFilterCollapsedState();
+    });
+    FILTER_TOGGLE_WIRED = true;
+  }
+  applyFilterCollapsedState();
+}
+
 function wireToolbar() {
   document.getElementById('btn-add').addEventListener('click', () => openCreate());
   document.getElementById('btn-save').addEventListener('click', async () => {

--- a/frontend/styles/list.css
+++ b/frontend/styles/list.css
@@ -10,6 +10,33 @@ body.page-list {
   flex-shrink: 0;
 }
 
+.filters-toggle-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 18px 0;
+}
+
+.filters-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.filters-toggle::before {
+  content: '▲';
+  font-size: 11px;
+  line-height: 1;
+}
+
+.filters-toggle[data-expanded='false']::before {
+  content: '▼';
+}
+
+.page-list.filters-collapsed .filters-toggle-row {
+  padding-bottom: 8px;
+}
+
 .list-summary {
   padding: 14px 18px 0;
   font-size: 13px;


### PR DESCRIPTION
## Summary
- add a toolbar control that allows the filter section to be collapsed on the task list view
- persist the collapse state, update accessibility attributes, and refresh the UI when filters rebuild
- style the toggle button with directional indicators to show when filters are hidden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900ace3831c832281cfb8b97add3d4e