### PR TITLE
Add dedicated horizontal scrollbar for task list

### DIFF
--- a/frontend/pages/list.html
+++ b/frontend/pages/list.html
@@ -94,8 +94,13 @@
   </aside>
 
   <div class="list-wrapper">
-    <div class="list-panel">
-      <div id="list-container" aria-live="polite"></div>
+    <div class="list-panel" id="list-panel">
+      <div class="list-panel-scroll" id="list-panel-scroll">
+        <div id="list-container" aria-live="polite"></div>
+      </div>
+    </div>
+    <div class="list-scrollbar" id="list-scrollbar" aria-hidden="true">
+      <div class="list-scrollbar-inner" id="list-scrollbar-inner"></div>
     </div>
   </div>
 

--- a/frontend/styles/list.css
+++ b/frontend/styles/list.css
@@ -241,6 +241,8 @@ body.page-list {
 .list-wrapper {
   flex: 1;
   display: flex;
+  flex-direction: column;
+  gap: 12px;
   padding: 0 18px 18px;
   min-height: 0;
 }
@@ -252,7 +254,49 @@ body.page-list {
   box-shadow: var(--shadow);
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+}
+
+.list-panel-scroll {
+  flex: 1;
+  min-height: 100%;
+  min-width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+  scrollbar-width: none;
+}
+
+.list-panel-scroll::-webkit-scrollbar {
+  height: 0;
+}
+
+.list-scrollbar {
+  flex-shrink: 0;
+  position: sticky;
+  bottom: 0;
+  height: 16px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.72);
+  box-shadow: var(--shadow);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.list-scrollbar::-webkit-scrollbar {
+  height: 10px;
+}
+
+.list-scrollbar.is-scroll-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.list-scrollbar-inner {
+  height: 1px;
 }
 
 table.task-list {
@@ -473,6 +517,7 @@ body.is-column-resizing * {
 
 @media (max-width: 720px) {
   .list-wrapper {
+    gap: 10px;
     padding: 0 12px 12px;
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated horizontal scrollbar beneath the task list and wrap the table in a horizontal scroller
- keep the custom scrollbar width in sync with renders, column resizing, and window resize events
- update styling so the new scrollbar sticks to the bottom of the viewport and native scrollbars stay hidden

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_6900b9ad98ec8322bf4efd9207795011