### PR TITLE
Ensure remarks use CRLF newlines when saving to Excel

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -300,6 +300,9 @@ class TaskStore:
 
         if isinstance(value, str):
             text = value.strip()
+            if col_name == "備考" and text:
+                normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+                text = normalized.replace("\n", "\r\n")
             return text if text else None
 
         return value


### PR DESCRIPTION
## Summary
- normalize newline characters in remark values before writing them to Excel so Excel recognizes line breaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69014a0c38f883228a2b3d1e99682ece