### PR TITLE
Add assignee autocomplete to task modals

### DIFF
--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -154,7 +154,8 @@
         </div>
         <div class="row">
           <label for="f-assignee">担当者</label>
-          <input type="text" id="f-assignee" />
+          <input type="text" id="f-assignee" list="modal-assignee-list" />
+          <datalist id="modal-assignee-list"></datalist>
         </div>
         <div class="row" style="grid-column: 1/-1;">
           <label for="f-title">タスク</label>

--- a/frontend/pages/list.html
+++ b/frontend/pages/list.html
@@ -156,7 +156,8 @@
         </div>
         <div class="row">
           <label for="f-assignee">担当者</label>
-          <input type="text" id="f-assignee" />
+          <input type="text" id="f-assignee" list="modal-assignee-list" />
+          <datalist id="modal-assignee-list"></datalist>
         </div>
         <div class="row" style="grid-column: 1/-1;">
           <label for="f-title">タスク</label>

--- a/frontend/pages/timeline.html
+++ b/frontend/pages/timeline.html
@@ -93,7 +93,8 @@
         </div>
         <div class="row">
           <label for="f-assignee">担当者</label>
-          <input type="text" id="f-assignee" />
+          <input type="text" id="f-assignee" list="modal-assignee-list" />
+          <datalist id="modal-assignee-list"></datalist>
         </div>
         <div class="row" style="grid-column: 1/-1;">
           <label for="f-title">タスク</label>

--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -1014,6 +1014,34 @@ function setupCategoryInputSuggestions(fmajor, fminor) {
   }
 }
 
+function setupAssigneeInputSuggestions(fassignee) {
+  const datalist = document.getElementById('modal-assignee-list');
+  if (!fassignee || !datalist) return;
+
+  const candidates = Array.isArray(TASKS) ? uniqAssignees() : [];
+  const seen = new Set();
+  datalist.innerHTML = '';
+
+  candidates.forEach(name => {
+    const text = String(name ?? '').trim();
+    if (!text || seen.has(text)) return;
+    seen.add(text);
+    const opt = document.createElement('option');
+    opt.value = text;
+    datalist.appendChild(opt);
+  });
+
+  const current = String(fassignee.value ?? '').trim();
+  if (current && !seen.has(current)) {
+    const opt = document.createElement('option');
+    opt.value = current;
+    datalist.appendChild(opt);
+    seen.add(current);
+  }
+
+  fassignee.setAttribute('list', datalist.id);
+}
+
 function openModal(task, { mode }) {
   const modal = document.getElementById('modal');
   const title = document.getElementById('modal-title');
@@ -1045,6 +1073,7 @@ function openModal(task, { mode }) {
   setupCategoryInputSuggestions(fmajor, fminor);
   fttl.value = task.タスク || '';
   fwho.value = task.担当者 || '';
+  setupAssigneeInputSuggestions(fwho);
   applyPriorityOptions(fprio, task.優先度, mode === 'create');
   fdue.value = (task.期限 || '').slice(0, 10);
   fnote.value = task.備考 || '';

--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -1632,6 +1632,34 @@ function setupCategoryInputSuggestions(fmajor, fminor) {
   }
 }
 
+function setupAssigneeInputSuggestions(fassignee) {
+  const datalist = document.getElementById('modal-assignee-list');
+  if (!fassignee || !datalist) return;
+
+  const candidates = Array.isArray(TASKS) ? uniqAssignees() : [];
+  const seen = new Set();
+  datalist.innerHTML = '';
+
+  candidates.forEach(name => {
+    const text = String(name ?? '').trim();
+    if (!text || seen.has(text)) return;
+    seen.add(text);
+    const opt = document.createElement('option');
+    opt.value = text;
+    datalist.appendChild(opt);
+  });
+
+  const current = String(fassignee.value ?? '').trim();
+  if (current && !seen.has(current)) {
+    const opt = document.createElement('option');
+    opt.value = current;
+    datalist.appendChild(opt);
+    seen.add(current);
+  }
+
+  fassignee.setAttribute('list', datalist.id);
+}
+
 function openModal(task, { mode }) {
   const modal = document.getElementById('modal');
   const title = document.getElementById('modal-title');
@@ -1663,6 +1691,7 @@ function openModal(task, { mode }) {
   setupCategoryInputSuggestions(fmajor, fminor);
   fttl.value = task.タスク || '';
   fwho.value = task.担当者 || '';
+  setupAssigneeInputSuggestions(fwho);
   applyPriorityOptions(fprio, task.優先度, mode === 'create');
   fdue.value = (task.期限 || '').slice(0, 10);
   fnote.value = task.備考 || '';

--- a/frontend/scripts/timeline.js
+++ b/frontend/scripts/timeline.js
@@ -630,6 +630,36 @@ function collectAllAssignees() {
   return Array.from(assignees).sort((a, b) => a.localeCompare(b, 'ja'));
 }
 
+function setupAssigneeInputSuggestions(fassignee) {
+  const datalist = document.getElementById('modal-assignee-list');
+  if (!fassignee || !datalist) return;
+
+  const candidates = collectAllAssignees()
+    .map(name => (name === ASSIGNEE_UNASSIGNED_LABEL ? '' : String(name ?? '').trim()))
+    .filter(Boolean);
+
+  const seen = new Set();
+  datalist.innerHTML = '';
+
+  candidates.forEach(name => {
+    if (seen.has(name)) return;
+    seen.add(name);
+    const opt = document.createElement('option');
+    opt.value = name;
+    datalist.appendChild(opt);
+  });
+
+  const current = String(fassignee.value ?? '').trim();
+  if (current && !seen.has(current)) {
+    const opt = document.createElement('option');
+    opt.value = current;
+    datalist.appendChild(opt);
+    seen.add(current);
+  }
+
+  fassignee.setAttribute('list', datalist.id);
+}
+
 function enumerateDays(from, to) {
   const days = [];
   const names = ['日', '月', '火', '水', '木', '金', '土'];
@@ -759,6 +789,7 @@ function openModal(task, { mode }) {
   if (fminor) fminor.value = task.中分類 || '';
   fttl.value = task.タスク || '';
   fwho.value = task.担当者 || '';
+  setupAssigneeInputSuggestions(fwho);
   applyPriorityOptions(fprio, task.優先度, mode === 'create');
   fdue.value = (task.期限 || '').slice(0, 10);
   fnote.value = task.備考 || '';


### PR DESCRIPTION
## Summary
- add datalist elements to the task modals so assignee fields support dropdown suggestions
- populate the datalist with the current set of assignees when opening the modal on each view while keeping manual entry available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901610f05e883228afe7f96cf15a04c