### PR TITLE
Remove category prefixes from list group headers

### DIFF
--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -405,8 +405,7 @@ function createGroupRow(type, label, count) {
 
   const title = document.createElement('span');
   title.className = 'group-label';
-  const prefix = type === 'major' ? '大分類' : '中分類';
-  title.textContent = `${prefix}: ${label}`;
+  title.textContent = label;
   cell.appendChild(title);
 
   if (typeof count === 'number' && Number.isFinite(count)) {


### PR DESCRIPTION
## Summary
- stop prefixing grouped task rows with "大分類:" and "中分類:" labels
- leave only the category name in the list view group headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690164e1ef8c832281c3c0bf6649806d