### PR TITLE
Add grouping context menu and refine timeline backlog display

### DIFF
--- a/frontend/scripts/timeline.js
+++ b/frontend/scripts/timeline.js
@@ -326,13 +326,10 @@ function renderLegend() {
 }
 
 function collectBacklogTasks(rangeFrom, rangeTo) {
-  if (!rangeFrom || !rangeTo || rangeFrom > rangeTo) {
-    return TASKS.filter(task => !parseISO(task.期限));
-  }
   return TASKS.filter(task => {
     const due = parseISO(task.期限);
-    if (!due) return true;
-    return due < rangeFrom || due > rangeTo;
+    const assignee = String(task.担当者 ?? '').trim();
+    return !due || !assignee;
   });
 }
 
@@ -567,6 +564,20 @@ function renderTaskChip(task) {
     no.textContent = `No.${task.No}`;
     meta.appendChild(no);
   }
+  const majorLabel = String(task.大分類 ?? '').trim();
+  const major = document.createElement('span');
+  major.textContent = `大分類: ${majorLabel || '未設定'}`;
+  meta.appendChild(major);
+
+  const minorLabel = String(task.中分類 ?? '').trim();
+  const minor = document.createElement('span');
+  minor.textContent = `中分類: ${minorLabel || '未設定'}`;
+  meta.appendChild(minor);
+
+  const priorityLabel = String(task.優先度 ?? '').trim();
+  const priority = document.createElement('span');
+  priority.textContent = `重要度: ${priorityLabel || '未設定'}`;
+  meta.appendChild(priority);
   if (task.備考) {
     const notes = document.createElement('span');
     notes.textContent = task.備考;

--- a/frontend/styles/list.css
+++ b/frontend/styles/list.css
@@ -420,6 +420,44 @@ table.task-list tbody tr.group-row:hover {
   background: transparent;
 }
 
+.group-context-menu {
+  position: absolute;
+  z-index: 2000;
+  min-width: 200px;
+  background: rgba(15, 23, 42, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 10px;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.55);
+  padding: 6px 0;
+  display: none;
+  backdrop-filter: blur(8px);
+}
+
+.group-context-menu.is-visible {
+  display: block;
+}
+
+.group-context-menu-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  color: #e2e8f0;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.group-context-menu-item:hover,
+.group-context-menu-item:focus {
+  background: rgba(59, 130, 246, 0.18);
+  color: #f8fafc;
+  outline: none;
+}
+
 
 table.task-list thead th .column-resizer {
   position: absolute;


### PR DESCRIPTION
## Summary
- enable a custom context menu on the task list grouping headers so new tasks inherit the selected categories
- restyle the list page to include the menu affordance
- adjust the timeline backlog to show only tasks without due dates or assignees and surface category/priority metadata on task chips

## Testing
- Manual (list.html)
- Manual (timeline.html)


------
https://chatgpt.com/codex/tasks/task_e_690195590b4c832298c4710e307725b8