### PR TITLE
Fix context menu positioning after scrolling

### DIFF
--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -540,7 +540,9 @@ function showGroupContextMenu(event, context) {
   menu.style.left = '-9999px';
   menu.style.top = '-9999px';
   menu.style.display = 'block';
-  positionContextMenu(menu, event.pageX, event.pageY);
+  const clientX = event.clientX ?? (event.pageX - (window.scrollX || window.pageXOffset || 0));
+  const clientY = event.clientY ?? (event.pageY - (window.scrollY || window.pageYOffset || 0));
+  positionContextMenu(menu, clientX, clientY);
 }
 
 document.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- ensure the list context menu uses client coordinates so it appears next to the pointer even after scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69019d8d63f483228790539a253481d0