### PR TITLE
Enable cross-major minor category filtering

### DIFF
--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -436,7 +436,7 @@ function buildFiltersUI() {
   const majorSel = document.getElementById('flt-major');
   const minorSel = document.getElementById('flt-minor');
   if (majorSel && minorSel) {
-    const { majorList, minorMap } = collectCategoryOptions();
+    const { majorList, minorMap, allMinors } = collectCategoryOptions();
     let currentMajor = FILTERS.category?.major ?? CATEGORY_FILTER_ALL;
     let currentMinor = FILTERS.category?.minor ?? CATEGORY_FILTER_MINOR_ALL;
 
@@ -451,38 +451,42 @@ function buildFiltersUI() {
     majorSel.innerHTML = majorOptions.join('');
     majorSel.value = currentMajor;
 
-    const renderMinorOptions = () => {
-      const majorsMinors = minorMap.get(currentMajor) || [];
+    const renderMinorOptions = ({ preserve = false } = {}) => {
+      const isAllMajor = currentMajor === CATEGORY_FILTER_ALL;
+      const majorsMinors = isAllMajor ? (allMinors || []) : (minorMap.get(currentMajor) || []);
       const minorOptions = [
         `<option value="${CATEGORY_FILTER_MINOR_ALL}">（すべて）</option>`
       ].concat(majorsMinors.map(name => `<option value="${name}">${name}</option>`));
       minorSel.innerHTML = minorOptions.join('');
 
-      if (currentMajor === CATEGORY_FILTER_ALL || majorsMinors.length === 0) {
-        minorSel.disabled = true;
+      if (!preserve) {
         currentMinor = CATEGORY_FILTER_MINOR_ALL;
-        minorSel.value = CATEGORY_FILTER_MINOR_ALL;
-        FILTERS.category.minor = CATEGORY_FILTER_MINOR_ALL;
+      }
+
+      if (currentMinor !== CATEGORY_FILTER_MINOR_ALL && !majorsMinors.includes(currentMinor)) {
+        currentMinor = CATEGORY_FILTER_MINOR_ALL;
+      }
+
+      if (majorsMinors.length === 0) {
+        currentMinor = CATEGORY_FILTER_MINOR_ALL;
+        minorSel.disabled = true;
       } else {
         minorSel.disabled = false;
-        if (majorsMinors.includes(currentMinor)) {
-          minorSel.value = currentMinor;
-        } else {
-          currentMinor = CATEGORY_FILTER_MINOR_ALL;
-          minorSel.value = CATEGORY_FILTER_MINOR_ALL;
-        }
-        FILTERS.category.minor = currentMinor;
       }
+
+      FILTERS.category.minor = currentMinor;
+      minorSel.value = currentMinor;
     };
 
-    renderMinorOptions();
+    renderMinorOptions({ preserve: true });
 
     majorSel.onchange = () => {
       currentMajor = majorSel.value;
       FILTERS.category.major = currentMajor;
-      currentMinor = CATEGORY_FILTER_MINOR_ALL;
-      FILTERS.category.minor = currentMinor;
-      renderMinorOptions();
+      if (currentMajor !== CATEGORY_FILTER_ALL) {
+        currentMinor = CATEGORY_FILTER_MINOR_ALL;
+      }
+      renderMinorOptions({ preserve: currentMajor === CATEGORY_FILTER_ALL });
       renderBoard();
     };
 
@@ -872,14 +876,16 @@ function getFilteredTasks() {
   const majorFilter = FILTERS.category?.major ?? CATEGORY_FILTER_ALL;
   const minorFilter = FILTERS.category?.minor ?? CATEGORY_FILTER_MINOR_ALL;
 
+  const shouldFilterMajor = majorFilter !== CATEGORY_FILTER_ALL;
+  const shouldFilterMinor = minorFilter !== CATEGORY_FILTER_MINOR_ALL;
+
   return TASKS.filter(t => {
-    if (majorFilter !== CATEGORY_FILTER_ALL) {
+    if (shouldFilterMajor || shouldFilterMinor) {
       const major = String(t.大分類 ?? '').trim();
-      if (major !== majorFilter) return false;
-      if (minorFilter !== CATEGORY_FILTER_MINOR_ALL) {
-        const minor = String(t.中分類 ?? '').trim();
-        if (minor !== minorFilter) return false;
-      }
+      const minor = String(t.中分類 ?? '').trim();
+
+      if (shouldFilterMajor && major !== majorFilter) return false;
+      if (shouldFilterMinor && minor !== minorFilter) return false;
     }
 
     // 担当者


### PR DESCRIPTION
## Summary
- allow selecting a minor category even when the major filter is set to "all" on both Kanban and list views
- ensure filtering logic treats major and minor filters independently so minor-only selections work across majors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901aaa9bea88322826cb13d71cd62cd