### PR TITLE
Color-code priority and status indicators

### DIFF
--- a/frontend/scripts/common.js
+++ b/frontend/scripts/common.js
@@ -344,6 +344,15 @@
     };
   }
 
+  function getPriorityLevel(value) {
+    const label = String(value ?? '').trim();
+    if (!label) return 'unset';
+    if (label === '低') return 'low';
+    if (label === '中') return 'medium';
+    if (label === '高') return 'high';
+    return 'custom';
+  }
+
   function setupRuntime({ onInit, onRealtimeUpdate, onApiChanged, mockApiFactory } = {}) {
     const state = {
       api: null,
@@ -807,5 +816,6 @@
     PRIORITY_DEFAULT_OPTIONS,
     DEFAULT_STATUSES,
     UNSET_STATUS_LABEL,
+    getPriorityLevel,
   };
 }(window));

--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -16,6 +16,7 @@ const {
   PRIORITY_DEFAULT_OPTIONS,
   DEFAULT_STATUSES,
   UNSET_STATUS_LABEL,
+  getPriorityLevel,
 } = window.TaskAppCommon;
 
 let api;                  // 実際に使う API （後で差し替える）
@@ -666,6 +667,10 @@ function renderCard(task) {
     const bp = document.createElement('span');
     bp.className = 'badge badge-priority';
     bp.textContent = `優先度: ${task.優先度}`;
+    const priorityLevel = getPriorityLevel(task.優先度);
+    if (priorityLevel && priorityLevel !== 'unset' && priorityLevel !== 'custom') {
+      bp.classList.add(`badge-priority-${priorityLevel}`);
+    }
     meta.appendChild(bp);
   }
   if (task.担当者) {

--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -16,6 +16,7 @@ const {
   PRIORITY_DEFAULT_OPTIONS,
   DEFAULT_STATUSES,
   UNSET_STATUS_LABEL,
+  getPriorityLevel,
 } = window.TaskAppCommon;
 
 let api;                  // 実際に使う API （後で差し替える）
@@ -59,6 +60,12 @@ const WORKLOAD_HEAVY_THRESHOLD = 5;
 const FILTER_COLLAPSED_STORAGE_KEY = 'taskList.filtersCollapsed';
 const GROUP_CONTEXT_MENU_ID = 'group-context-menu';
 let GROUP_CONTEXT_STATE = null;
+
+const STATUS_CLASS_MAP = new Map([
+  ['進行中', 'status-pill--in-progress'],
+  ['保留', 'status-pill--on-hold'],
+  ['完了', 'status-pill--done'],
+]);
 
 function applyFilterCollapsedState() {
   const container = document.getElementById('filters-bar');
@@ -1087,7 +1094,12 @@ function renderList() {
     applyColumnBaseStyles(statusTd, 'status');
     const statusPill = document.createElement('span');
     statusPill.className = 'status-pill';
-    statusPill.textContent = normalizeStatusLabel(task.ステータス);
+    const statusLabel = normalizeStatusLabel(task.ステータス);
+    statusPill.textContent = statusLabel;
+    const statusClass = STATUS_CLASS_MAP.get(statusLabel);
+    if (statusClass) {
+      statusPill.classList.add(statusClass);
+    }
     statusTd.appendChild(statusPill);
     tr.appendChild(statusTd);
 
@@ -1102,6 +1114,10 @@ function renderList() {
       const pill = document.createElement('span');
       pill.className = 'priority-pill';
       pill.textContent = `優先度: ${task.優先度}`;
+      const priorityLevel = getPriorityLevel(task.優先度);
+      if (priorityLevel && priorityLevel !== 'unset' && priorityLevel !== 'custom') {
+        pill.classList.add(`priority-pill--${priorityLevel}`);
+      }
       priorityTd.appendChild(pill);
     }
     tr.appendChild(priorityTd);

--- a/frontend/styles/kanban.css
+++ b/frontend/styles/kanban.css
@@ -146,8 +146,27 @@ body.page-kanban {
 }
 
 .badge-priority {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.15);
+  color: #e2e8f0;
+}
+
+.badge-priority-high {
   color: #fca5a5;
-  background: rgba(239, 68, 68, 0.15);
+  background: rgba(239, 68, 68, 0.18);
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.badge-priority-medium {
+  color: #fde68a;
+  background: rgba(245, 158, 11, 0.2);
+  border-color: rgba(245, 158, 11, 0.45);
+}
+
+.badge-priority-low {
+  color: #bbf7d0;
+  background: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.45);
 }
 
 .card-meta {

--- a/frontend/styles/list.css
+++ b/frontend/styles/list.css
@@ -510,6 +510,26 @@ body.is-column-resizing * {
 
 .status-pill {
   border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.15);
+  color: #e2e8f0;
+}
+
+.status-pill--in-progress {
+  border-color: rgba(34, 197, 94, 0.45);
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+}
+
+.status-pill--on-hold {
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.status-pill--done {
+  border-color: rgba(147, 51, 234, 0.5);
+  background: rgba(147, 51, 234, 0.2);
+  color: #e9d5ff;
 }
 
 .category-pill {
@@ -530,9 +550,27 @@ body.is-column-resizing * {
 }
 
 .priority-pill {
-  background: rgba(239, 68, 68, 0.15);
-  border: 1px solid rgba(239, 68, 68, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.15);
+  color: #e2e8f0;
+}
+
+.priority-pill--high {
+  border-color: rgba(239, 68, 68, 0.45);
+  background: rgba(239, 68, 68, 0.18);
   color: #fca5a5;
+}
+
+.priority-pill--medium {
+  border-color: rgba(245, 158, 11, 0.45);
+  background: rgba(245, 158, 11, 0.2);
+  color: #fde68a;
+}
+
+.priority-pill--low {
+  border-color: rgba(16, 185, 129, 0.45);
+  background: rgba(16, 185, 129, 0.18);
+  color: #bbf7d0;
 }
 
 .due-badge {


### PR DESCRIPTION
## Summary
- add a shared helper to classify priority labels
- color-code kanban and list priority badges using the helper
- style list statuses with dedicated colors for in-progress, on-hold (with a softer tint), and completed entries

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_6901bca003c8832295918ed9d10495e7