### PR TITLE
Fix context menu positioning to use viewport coordinates

### DIFF
--- a/frontend/styles/list.css
+++ b/frontend/styles/list.css
@@ -421,7 +421,7 @@ table.task-list tbody tr.group-row:hover {
 }
 
 .group-context-menu {
-  position: absolute;
+  position: fixed;
   z-index: 2000;
   min-width: 200px;
   background: rgba(15, 23, 42, 0.96);


### PR DESCRIPTION
## Summary
- change the group context menu to use fixed positioning so it aligns with viewport coordinates expected by the JavaScript

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901c4f1a9c48322b50675b46f086a8d