### PR TITLE
Adjust calendar backlog filtering and legend colors

### DIFF
--- a/frontend/pages/calendar.html
+++ b/frontend/pages/calendar.html
@@ -42,7 +42,7 @@
       <div class="backlog-header">
         <h2 class="backlog-title">バックログ</h2>
         <p class="backlog-description">
-          期限未設定または表示月以外のタスクです。ここから日付セルへドラッグすると期限を変更できます。
+          期限が未設定のタスクです。ここから日付セルへドラッグすると期限を変更できます。
         </p>
       </div>
       <div class="calendar-backlog-drop" id="calendar-backlog-drop" aria-label="期限を未設定にするドロップエリア">


### PR DESCRIPTION
## Summary
- limit the calendar backlog view to only include tasks without a due date and update its description copy
- ensure the calendar legend always lists the core statuses with their intended colors, including an entry for unset statuses when present
- normalize status color lookup to tolerate whitespace and common synonyms so chips and the legend stay in sync

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6901d513546c8322b9566a206744cd4d