### PR TITLE
Add session-aware frontend snapshot loading

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -500,6 +500,17 @@ class TaskStore:
         with self._lock:
             return {k: list(v) for k, v in self._validations.items()}
 
+    def get_state_snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            tasks = [self._format_row(i, self._df.iloc[i]) for i in range(len(self._df))]
+            statuses = list(self._statuses)
+            validations = {k: list(v) for k, v in self._validations.items()}
+            return {
+                "tasks": tasks,
+                "statuses": statuses,
+                "validations": validations,
+            }
+
     def set_validations(self, mapping: Dict[str, List[Any]]):
         with self._lock:
             cleaned: Dict[str, List[str]] = {}
@@ -859,6 +870,9 @@ class JsApi:
 
     def get_validations(self) -> Dict[str, List[str]]:
         return self.store.get_validations()
+
+    def get_state_snapshot(self) -> Dict[str, Any]:
+        return self.store.get_state_snapshot()
 
     def update_validations(self, payload: Any) -> Dict[str, Any]:
         data = json.loads(payload) if isinstance(payload, str) else payload

--- a/frontend/scripts/common.js
+++ b/frontend/scripts/common.js
@@ -194,6 +194,13 @@
           statuses: Array.from(statusSet),
           validations: { ...validations }
         };
+      },
+      async get_state_snapshot() {
+        return {
+          tasks: withSequentialNo(),
+          statuses: Array.from(statusSet),
+          validations: { ...validations }
+        };
       }
     };
   }

--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -23,6 +23,32 @@ let api;                  // 実際に使う API （後で差し替える）
 let RUN_MODE = 'mock';    // 'mock' | 'pywebview'
 let WIRED = false;        // ツールバー多重バインド防止
 
+const INITIAL_LOAD_FLAG_KEY = 'kanban:excelLoaded';
+
+function hasInitialExcelLoadFlag() {
+  try {
+    return window.sessionStorage?.getItem(INITIAL_LOAD_FLAG_KEY) === '1';
+  } catch (err) {
+    return false;
+  }
+}
+
+function markInitialExcelLoadFlag() {
+  try {
+    window.sessionStorage?.setItem(INITIAL_LOAD_FLAG_KEY, '1');
+  } catch (err) {
+    // ignore
+  }
+}
+
+function resetInitialExcelLoadFlag() {
+  try {
+    window.sessionStorage?.removeItem(INITIAL_LOAD_FLAG_KEY);
+  } catch (err) {
+    // ignore
+  }
+}
+
 /* ===================== 状態 ===================== */
 const VALIDATION_COLUMNS = ["ステータス", "大分類", "中分類", "タスク", "担当者", "優先度", "期限", "備考"];
 const ASSIGNEE_FILTER_ALL = '__ALL__';
@@ -161,11 +187,20 @@ setupRuntime({
     console.log('[list] run mode:', RUN_MODE);
   },
   onInit: async () => {
-    await init(true);
+    try {
+      await init(true);
+      if (RUN_MODE === 'pywebview') {
+        markInitialExcelLoadFlag();
+      }
+    } catch (err) {
+      resetInitialExcelLoadFlag();
+      throw err;
+    }
   },
-  onRealtimeUpdate: (payload) => (
-    applyStateFromPayload(payload, { preserveFilters: true, fallbackToApi: false })
-  ),
+  onRealtimeUpdate: (payload) => {
+    resetInitialExcelLoadFlag();
+    return applyStateFromPayload(payload, { preserveFilters: true, fallbackToApi: false });
+  },
 });
 
 const STATUS_SORT_SEQUENCE = ['', UNSET_STATUS_LABEL, '未着手', '進行中', '完了', '保留中'];
@@ -813,6 +848,7 @@ async function applyStateFromPayload(payload, options = {}) {
 }
 
 window.__kanban_receive_update = (payload) => {
+  resetInitialExcelLoadFlag();
   Promise.resolve(
     applyStateFromPayload(payload, { preserveFilters: true, fallbackToApi: false })
   ).catch(err => {
@@ -915,12 +951,23 @@ function syncFilterStatuses(prevSelection) {
 async function init(force = false) {
   let payload = {};
   if (force) {
-    if (RUN_MODE === 'pywebview' && typeof api.reload_from_excel === 'function') {
+    const isPywebview = RUN_MODE === 'pywebview';
+    let loadedViaReload = false;
+    if (isPywebview && !hasInitialExcelLoadFlag() && typeof api.reload_from_excel === 'function') {
       try {
         payload = normalizeStatePayload(await api.reload_from_excel());
+        loadedViaReload = true;
       } catch (e) {
         console.warn('reload_from_excel failed, fallback to get_*', e);
         payload = {};
+      }
+    }
+
+    if (isPywebview && !loadedViaReload && typeof api.get_state_snapshot === 'function') {
+      try {
+        payload = normalizeStatePayload(await api.get_state_snapshot());
+      } catch (err) {
+        console.warn('get_state_snapshot failed:', err);
       }
     }
 
@@ -1555,6 +1602,7 @@ function wireToolbar() {
   });
   validationsBtn.addEventListener('click', () => openValidationModal());
   reloadBtn.addEventListener('click', async () => {
+    resetInitialExcelLoadFlag();
     try {
       const payload = await api.reload_from_excel();
       await applyStateFromPayload(payload, { preserveFilters: true, fallbackToApi: true });

--- a/frontend/scripts/timeline.js
+++ b/frontend/scripts/timeline.js
@@ -25,6 +25,32 @@ const ASSIGNEE_FILTER_UNASSIGNED = '__UNASSIGNED__';
 const ASSIGNEE_UNASSIGNED_LABEL = '（未割り当て）';
 let cleanupAutoScroll = null;
 
+const INITIAL_LOAD_FLAG_KEY = 'kanban:excelLoaded';
+
+function hasInitialExcelLoadFlag() {
+  try {
+    return window.sessionStorage?.getItem(INITIAL_LOAD_FLAG_KEY) === '1';
+  } catch (err) {
+    return false;
+  }
+}
+
+function markInitialExcelLoadFlag() {
+  try {
+    window.sessionStorage?.setItem(INITIAL_LOAD_FLAG_KEY, '1');
+  } catch (err) {
+    // ignore
+  }
+}
+
+function resetInitialExcelLoadFlag() {
+  try {
+    window.sessionStorage?.removeItem(INITIAL_LOAD_FLAG_KEY);
+  } catch (err) {
+    // ignore
+  }
+}
+
 const priorityHelper = createPriorityHelper({
   getValidations: () => VALIDATIONS,
   defaultOptions: PRIORITY_DEFAULT_OPTIONS,
@@ -43,11 +69,20 @@ setupRuntime({
     console.log('[timeline] run mode:', RUN_MODE);
   },
   onInit: async () => {
-    await init(true);
+    try {
+      await init(true);
+      if (RUN_MODE === 'pywebview') {
+        markInitialExcelLoadFlag();
+      }
+    } catch (err) {
+      resetInitialExcelLoadFlag();
+      throw err;
+    }
   },
-  onRealtimeUpdate: (payload) => (
-    applyStateFromPayload(payload, { fallbackToApi: false })
-  ),
+  onRealtimeUpdate: (payload) => {
+    resetInitialExcelLoadFlag();
+    return applyStateFromPayload(payload, { fallbackToApi: false });
+  },
 });
 
 ready(() => {
@@ -62,18 +97,23 @@ async function init(force = false) {
   if (force) {
     let payload = {};
     try {
-      if (RUN_MODE === 'pywebview' && typeof api.reload_from_excel === 'function') {
-        payload = await api.reload_from_excel();
-      } else {
-        if (typeof api.get_tasks === 'function') {
-          payload.tasks = await api.get_tasks();
-        }
-        if (typeof api.get_statuses === 'function') {
-          payload.statuses = await api.get_statuses();
-        }
-        if (typeof api.get_validations === 'function') {
-          payload.validations = await api.get_validations();
-        }
+      const isPywebview = RUN_MODE === 'pywebview';
+      let loadedViaReload = false;
+      if (isPywebview && !hasInitialExcelLoadFlag() && typeof api.reload_from_excel === 'function') {
+        payload = normalizeStatePayload(await api.reload_from_excel());
+        loadedViaReload = true;
+      }
+      if (isPywebview && !loadedViaReload && typeof api.get_state_snapshot === 'function') {
+        payload = normalizeStatePayload(await api.get_state_snapshot());
+      }
+      if (!Array.isArray(payload.tasks) && typeof api.get_tasks === 'function') {
+        payload.tasks = await api.get_tasks();
+      }
+      if (!Array.isArray(payload.statuses) && typeof api.get_statuses === 'function') {
+        payload.statuses = await api.get_statuses();
+      }
+      if (payload.validations === undefined && typeof api.get_validations === 'function') {
+        payload.validations = await api.get_validations();
       }
     } catch (err) {
       console.error('init failed', err);


### PR DESCRIPTION
## Summary
- expose a get_state_snapshot method from the backend store and JsApi so clients can fetch cached tasks without reloading Excel
- update the mock API and all front-end entry points to persist a per-session flag, only calling reload_from_excel on the first initialization and using the snapshot afterwards
- reset the session flag when manual reloads or pushed updates arrive so that later initializations can force another Excel read when needed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902074d1110832291b9b80373cdd1f4