### PR TITLE
Add quick due-date presets to kanban and list views

### DIFF
--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -77,6 +77,10 @@
         <input type="date" id="flt-date-from" />
         <span id="flt-date-sep" style="display:none;">〜</span>
         <input type="date" id="flt-date-to" style="display:none;" />
+        <div class="due-quick-buttons" style="display:flex; gap:4px;">
+          <button type="button" class="btn btn-ghost" data-due-preset="this-week">今週まで</button>
+          <button type="button" class="btn btn-ghost" data-due-preset="next-week">来週まで</button>
+        </div>
       </div>
     </div>
 

--- a/frontend/pages/list.html
+++ b/frontend/pages/list.html
@@ -73,6 +73,10 @@
         <input type="date" id="flt-date-from" />
         <span id="flt-date-sep" style="display:none;">〜</span>
         <input type="date" id="flt-date-to" style="display:none;" />
+        <div class="due-quick-buttons" style="display:flex; gap:4px;">
+          <button type="button" class="btn btn-ghost" data-due-preset="this-week">今週まで</button>
+          <button type="button" class="btn btn-ghost" data-due-preset="next-week">来週まで</button>
+        </div>
       </div>
     </div>
 

--- a/frontend/scripts/common.js
+++ b/frontend/scripts/common.js
@@ -709,6 +709,64 @@
     return Number.isNaN(dt.getTime()) ? null : dt;
   }
 
+  function formatDateInputValue(date) {
+    if (!date) return '';
+    const dt = date instanceof Date ? new Date(date.getTime()) : parseISODate(date);
+    if (!dt || Number.isNaN(dt.getTime())) return '';
+    const year = dt.getFullYear();
+    const month = String(dt.getMonth() + 1).padStart(2, '0');
+    const day = String(dt.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  function startOfWeek(date) {
+    const base = date instanceof Date ? new Date(date.getTime()) : parseISODate(date);
+    if (!base || Number.isNaN(base.getTime())) return null;
+    base.setHours(0, 0, 0, 0);
+    base.setDate(base.getDate() - base.getDay());
+    return base;
+  }
+
+  function endOfWeek(date) {
+    const start = startOfWeek(date);
+    if (!start) return null;
+    const end = new Date(start.getTime());
+    end.setDate(start.getDate() + 6);
+    return end;
+  }
+
+  function getDueFilterPreset(presetName, options = {}) {
+    const name = String(presetName ?? '').trim();
+    const todayBase = options.today instanceof Date
+      ? new Date(options.today.getTime())
+      : new Date();
+    todayBase.setHours(0, 0, 0, 0);
+
+    const result = { mode: 'none', from: '', to: '' };
+
+    if (name === 'this-week') {
+      const weekEnd = endOfWeek(todayBase);
+      if (!weekEnd) return null;
+      result.mode = 'before';
+      result.from = formatDateInputValue(weekEnd);
+      return result;
+    }
+
+    if (name === 'next-week') {
+      const weekStart = startOfWeek(todayBase);
+      if (!weekStart) return null;
+      const nextWeekStart = new Date(weekStart.getTime());
+      nextWeekStart.setDate(weekStart.getDate() + 7);
+      const nextWeekEnd = new Date(nextWeekStart.getTime());
+      nextWeekEnd.setDate(nextWeekStart.getDate() + 6);
+      result.mode = 'before';
+      result.from = formatDateInputValue(nextWeekEnd);
+      return result;
+    }
+
+    return null;
+  }
+
   function isCompletedStatus(value) {
     const text = String(value ?? '').trim();
     if (!text) return false;
@@ -1104,5 +1162,6 @@
     DEFAULT_STATUSES,
     UNSET_STATUS_LABEL,
     getPriorityLevel,
+    getDueFilterPreset,
   };
 }(window));

--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -21,6 +21,7 @@ const {
   DEFAULT_STATUSES,
   UNSET_STATUS_LABEL,
   getPriorityLevel,
+  getDueFilterPreset,
 } = window.TaskAppCommon;
 
 let api;                  // 実際に使う API （後で差し替える）
@@ -870,6 +871,27 @@ function buildFiltersUI() {
   modeSel.onchange = () => { FILTERS.date.mode = modeSel.value; updateVisibility(); renderBoard(); };
   fromEl.onchange = () => { FILTERS.date.from = fromEl.value; renderBoard(); };
   toEl.onchange = () => { FILTERS.date.to = toEl.value; renderBoard(); };
+
+  const applyDuePreset = (presetName) => {
+    const preset = getDueFilterPreset(presetName);
+    if (!preset) return;
+    FILTERS.date.mode = preset.mode;
+    FILTERS.date.from = preset.from;
+    FILTERS.date.to = preset.to;
+    modeSel.value = FILTERS.date.mode;
+    fromEl.value = FILTERS.date.from;
+    toEl.value = FILTERS.date.to;
+    updateVisibility();
+    renderBoard();
+  };
+
+  document.querySelectorAll('[data-due-preset]').forEach(btn => {
+    if (!btn || btn.dataset.bound === '1') return;
+    btn.dataset.bound = '1';
+    btn.addEventListener('click', () => {
+      applyDuePreset(btn.dataset.duePreset || '');
+    });
+  });
 
   // 解除ボタン
   document.getElementById('btn-clear-filters').onclick = () => {

--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -21,6 +21,7 @@ const {
   DEFAULT_STATUSES,
   UNSET_STATUS_LABEL,
   getPriorityLevel,
+  getDueFilterPreset,
 } = window.TaskAppCommon;
 
 let api;                  // 実際に使う API （後で差し替える）
@@ -1751,6 +1752,27 @@ function buildFiltersUI() {
   modeSel.onchange = () => { FILTERS.date.mode = modeSel.value; updateVisibility(); renderList(); };
   fromEl.onchange = () => { FILTERS.date.from = fromEl.value; renderList(); };
   toEl.onchange = () => { FILTERS.date.to = toEl.value; renderList(); };
+
+  const applyDuePreset = (presetName) => {
+    const preset = getDueFilterPreset(presetName);
+    if (!preset) return;
+    FILTERS.date.mode = preset.mode;
+    FILTERS.date.from = preset.from;
+    FILTERS.date.to = preset.to;
+    modeSel.value = FILTERS.date.mode;
+    fromEl.value = FILTERS.date.from;
+    toEl.value = FILTERS.date.to;
+    updateVisibility();
+    renderList();
+  };
+
+  document.querySelectorAll('[data-due-preset]').forEach(btn => {
+    if (!btn || btn.dataset.bound === '1') return;
+    btn.dataset.bound = '1';
+    btn.addEventListener('click', () => {
+      applyDuePreset(btn.dataset.duePreset || '');
+    });
+  });
 
   // 解除ボタン
   document.getElementById('btn-clear-filters').onclick = () => {


### PR DESCRIPTION
## Summary
- add quick "this week" and "next week" preset buttons to the kanban and list due-date filters
- centralize due-date preset calculation so both views share the same logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902a18c5d80832294b6910379065cbd