### PR TITLE
Update default due date ordering in Kanban and list views

### DIFF
--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -365,7 +365,9 @@ function renderBoard() {
 
     // ↓ 絞り込み済みから、その列のカードを描画
     columnTasks
-      .sort((a, b) => comparePriorityValues(a.優先度, b.優先度) || (a.No || 0) - (b.No || 0))
+      .sort((a, b) => compareDueValues(a, b)
+        || comparePriorityValues(a.優先度, b.優先度)
+        || (a.No || 0) - (b.No || 0))
       .forEach(task => drop.appendChild(renderCard(task)));
 
     body.appendChild(drop);
@@ -490,6 +492,19 @@ function comparePriorityValues(a, b) {
   const kb = prioritySortKey(b);
   if (ka.weight !== kb.weight) return ka.weight - kb.weight;
   return ka.label.localeCompare(kb.label, 'ja');
+}
+
+function compareDueValues(a, b) {
+  const da = parseISO(a?.期限 || '');
+  const db = parseISO(b?.期限 || '');
+  if (da && db) {
+    const diff = da.getTime() - db.getTime();
+    if (diff !== 0) return diff;
+    return 0;
+  }
+  if (da) return -1;
+  if (db) return 1;
+  return 0;
 }
 
 function renderCard(task) {

--- a/frontend/scripts/list.js
+++ b/frontend/scripts/list.js
@@ -795,6 +795,8 @@ function defaultListComparator(a, b, statusOrder) {
   const sa = statusOrder.has(normalizedA) ? statusOrder.get(normalizedA) : 999;
   const sb = statusOrder.has(normalizedB) ? statusOrder.get(normalizedB) : 999;
   if (sa !== sb) return sa - sb;
+  const due = compareDueValues(a, b);
+  if (due !== 0) return due;
   const pri = comparePriorityValues(a.優先度, b.優先度);
   if (pri !== 0) return pri;
   return compareNoValues(a, b);
@@ -1195,12 +1197,18 @@ function handleSortToggle(columnKey) {
   if (!column || !column.sortable) return;
 
   const idx = SORT_STATE.findIndex(entry => entry.key === columnKey);
+  const cycle = columnKey === 'due' ? ['desc', 'asc'] : ['asc', 'desc'];
+
   if (idx === -1) {
-    SORT_STATE.push({ key: columnKey, direction: 'asc' });
-  } else if (SORT_STATE[idx].direction === 'asc') {
-    SORT_STATE[idx].direction = 'desc';
+    SORT_STATE.push({ key: columnKey, direction: cycle[0] });
   } else {
-    SORT_STATE.splice(idx, 1);
+    const current = SORT_STATE[idx].direction;
+    const position = cycle.indexOf(current);
+    if (position >= 0 && position < cycle.length - 1) {
+      SORT_STATE[idx].direction = cycle[position + 1];
+    } else {
+      SORT_STATE.splice(idx, 1);
+    }
   }
 
   renderList();


### PR DESCRIPTION
## Summary
- order Kanban cards by ascending due date before priority to highlight near-term work
- include due date in the list view default comparator so earlier deadlines appear first
- reverse the due column sort cycle so the first toggle now shows descending dates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690441f4d9b48322830285c624a5ee21