### PR TITLE
Refactor task pages to share runtime setup

### DIFF
--- a/frontend/pages/index.html
+++ b/frontend/pages/index.html
@@ -118,6 +118,7 @@
   <script src="../scripts/appRuntime.js" defer></script>
   <script src="../scripts/header.js" defer></script>
   <script src="../scripts/filter-ui.js" defer></script>
+  <script src="../scripts/pageBase.js" defer></script>
   <script src="../scripts/index.js" defer></script>
 </body>
 

--- a/frontend/pages/list.html
+++ b/frontend/pages/list.html
@@ -121,6 +121,7 @@
   <script src="../scripts/appRuntime.js" defer></script>
   <script src="../scripts/header.js" defer></script>
   <script src="../scripts/filter-ui.js" defer></script>
+  <script src="../scripts/pageBase.js" defer></script>
   <script src="../scripts/list.js" defer></script>
 </body>
 

--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -1,22 +1,16 @@
 /* ===================== ランタイム切替（mock / pywebview） ===================== */
 const {
-  createMockApi,
   sanitizeTaskRecord,
   sanitizeTaskList,
   normalizeStatePayload,
   parseISO,
   getDueState,
-  createWorkloadSummary,
   getPriorityLevel,
-  getDueFilterPreset,
 } = window.TaskAppCommon;
 
 const {
-  setupRuntime,
   hasInitialExcelLoadFlag,
-  markInitialExcelLoadFlag,
   resetInitialExcelLoadFlag,
-  bindExcelActions,
 } = window.TaskAppRuntime || {};
 
 const {
@@ -37,8 +31,9 @@ const {
     CATEGORY_FILTER_ALL,
     CATEGORY_FILTER_MINOR_ALL,
   },
-  createController: createFilterController,
 } = window.TaskFilterUI;
+
+const { createTaskPageBase } = window.TaskPageBase || {};
 
 let api;                  // 実際に使う API （後で差し替える）
 let RUN_MODE = 'mock';    // 'mock' | 'pywebview'
@@ -58,33 +53,6 @@ const getDefaultPriorityValue = () => priorityHelper.getDefaultValue();
 const applyPriorityOptions = (selectEl, currentValue, preferDefault = false) => (
   priorityHelper.applyOptions(selectEl, currentValue, preferDefault)
 );
-
-const FILTER_PRESET_VIEW_KEY = 'kanban-board';
-let filterController;
-
-const headerController = window.TaskAppHeader?.initHeader({
-  title: 'タスク・カンバン',
-  currentView: 'kanban',
-  hint: 'ドラッグ＆ドロップで列に移動できます',
-  onAdd: () => openCreate(),
-  onSave: () => handleSaveToExcel(),
-  onValidations: () => openValidationModal(),
-  onReload: () => handleReloadFromExcel(),
-});
-
-function initFilterController() {
-  const container = document.getElementById('filters-bar');
-  filterController = createFilterController({
-    container,
-    viewKey: FILTER_PRESET_VIEW_KEY,
-    onChange: () => {
-      renderBoard();
-    },
-    normalizeStatusLabel,
-    parseISO,
-    getDueFilterPreset,
-  });
-}
 
 const WORKLOAD_IN_PROGRESS_KEYWORDS = ['進行', '作業中', 'inprogress', 'wip'];
 const WORKLOAD_HEAVY_THRESHOLD = 5;
@@ -110,64 +78,47 @@ function workloadHighlightPredicate(entry) {
   return workloadInProgressCount(entry) > WORKLOAD_HEAVY_THRESHOLD;
 }
 
-initFilterController();
-
-const workloadSummary = createWorkloadSummary({
-  container: document.getElementById('workload-summary'),
-  getStatuses: () => STATUSES,
-  normalizeStatusLabel,
-  unassignedKey: ASSIGNEE_FILTER_UNASSIGNED,
-  unassignedLabel: ASSIGNEE_UNASSIGNED_LABEL,
-  allKey: ASSIGNEE_FILTER_ALL,
-  getActiveAssignee: () => filterController?.getFilters().assignee ?? ASSIGNEE_FILTER_ALL,
-  getDueState,
-  highlightPredicate: workloadHighlightPredicate,
-  onSelectAssignee: (value) => {
-    const next = (() => {
-      const current = filterController?.getFilters().assignee ?? ASSIGNEE_FILTER_ALL;
-      if (!value || value === ASSIGNEE_FILTER_ALL) return ASSIGNEE_FILTER_ALL;
-      if (current === value) return ASSIGNEE_FILTER_ALL;
-      return value;
-    })();
-    if (filterController) {
-      filterController.setAssignee(next);
-      const select = document.getElementById('flt-assignee');
-      if (select) {
-        select.value = next;
-      }
-    }
-  },
-});
-
-if (typeof setupRuntime === 'function') {
-  setupRuntime({
-    mockApiFactory: createMockApi,
+const pageBase = typeof createTaskPageBase === 'function'
+  ? createTaskPageBase({
+    viewKey: 'kanban-board',
+    headerOptions: {
+      title: 'タスク・カンバン',
+      currentView: 'kanban',
+      hint: 'ドラッグ＆ドロップで列に移動できます',
+      onAdd: () => openCreate(),
+      onSave: () => handleSaveToExcel(),
+      onValidations: () => openValidationModal(),
+      onReload: () => handleReloadFromExcel(),
+    },
+    onRender: () => renderBoard(),
+    onInit: () => init(true),
+    onRealtimeUpdate: (payload) => applyStateFromPayload(payload, { preserveFilters: true, fallbackToApi: false }),
+    onSave: () => handleSaveToExcel(),
+    onReload: () => handleReloadFromExcel(),
     onApiChanged: ({ api: nextApi, runMode }) => {
       api = nextApi;
       RUN_MODE = runMode;
       console.log('[kanban] run mode:', RUN_MODE);
     },
-    onInit: async () => {
-      try {
-        await init(true);
-        if (RUN_MODE === 'pywebview') {
-          markInitialExcelLoadFlag?.();
-        }
-      } catch (err) {
-        resetInitialExcelLoadFlag?.();
-        throw err;
-      }
-    },
-    onRealtimeUpdate: (payload) => applyStateFromPayload(payload, { preserveFilters: true, fallbackToApi: false }),
-  });
-}
+    getStatuses: () => STATUSES,
+    highlightPredicate: (entry) => workloadHighlightPredicate(entry),
+    logLabel: 'kanban',
+  })
+  : {
+    headerController: window.TaskAppHeader?.initHeader?.({
+      title: 'タスク・カンバン',
+      currentView: 'kanban',
+      hint: 'ドラッグ＆ドロップで列に移動できます',
+      onAdd: () => openCreate(),
+      onSave: () => handleSaveToExcel(),
+      onValidations: () => openValidationModal(),
+      onReload: () => handleReloadFromExcel(),
+    }),
+    filterController: null,
+    workloadSummary: null,
+  };
 
-if (typeof bindExcelActions === 'function') {
-  bindExcelActions({
-    onSave: () => handleSaveToExcel(),
-    onReload: () => handleReloadFromExcel(),
-  });
-}
+const { filterController, workloadSummary, headerController } = pageBase;
 
 async function applyStateFromPayload(payload, options = {}) {
   const { preserveFilters = true, fallbackToApi = true } = options;
@@ -200,7 +151,7 @@ async function applyStateFromPayload(payload, options = {}) {
     ? snapshot.validations
     : VALIDATIONS;
 
-  filterController.updateData({
+  filterController?.updateData({
     tasks: TASKS,
     statuses: STATUSES,
     validations: VALIDATIONS,
@@ -314,7 +265,7 @@ function renderBoard() {
 
 function buildAssigneeWorkload(tasks) {
   const list = Array.isArray(tasks) ? tasks : [];
-  workloadSummary.update(list, {
+  workloadSummary?.update(list, {
     total: list.length,
     overall: Array.isArray(TASKS) ? TASKS.length : list.length,
   });
@@ -633,7 +584,7 @@ function openValidationModal() {
         } else {
           applyValidationState(payload);
         }
-        filterController.updateData({
+        filterController?.updateData({
           tasks: TASKS,
           statuses: STATUSES,
           validations: VALIDATIONS,
@@ -659,7 +610,7 @@ function closeValidationModal() {
 }
 
 function getFilteredTasks() {
-  return filterController.applyFilters(TASKS);
+  return filterController?.applyFilters(TASKS) ?? TASKS;
 }
 
 
@@ -832,7 +783,7 @@ function openModal(task, { mode }) {
         }
         CURRENT_EDIT = null;
         closeModal();
-        filterController.updateData({
+        filterController?.updateData({
           tasks: TASKS,
           statuses: STATUSES,
           validations: VALIDATIONS,
@@ -888,7 +839,7 @@ function openModal(task, { mode }) {
         }
       }
       closeModal();
-      filterController.updateData({
+      filterController?.updateData({
         tasks: TASKS,
         statuses: STATUSES,
         validations: VALIDATIONS,

--- a/frontend/scripts/pageBase.js
+++ b/frontend/scripts/pageBase.js
@@ -1,0 +1,190 @@
+(function () {
+  const {
+    createMockApi,
+    createWorkloadSummary,
+    getDueFilterPreset,
+    parseISO,
+    getDueState,
+  } = window.TaskAppCommon || {};
+
+  const {
+    setupRuntime,
+    markInitialExcelLoadFlag,
+    resetInitialExcelLoadFlag,
+    bindExcelActions,
+  } = window.TaskAppRuntime || {};
+
+  const { normalizeStatusLabel } = window.TaskValidation || {};
+
+  const {
+    constants: {
+      ASSIGNEE_FILTER_ALL,
+      ASSIGNEE_FILTER_UNASSIGNED,
+      ASSIGNEE_UNASSIGNED_LABEL,
+    } = {},
+    createController,
+  } = window.TaskFilterUI || {};
+
+  const DEFAULT_WORKLOAD_HIGHLIGHT = () => false;
+
+  function defaultAssigneeSelectHandler(value, context) {
+    const controller = context?.filterController;
+    if (!controller || typeof controller.getFilters !== 'function') {
+      return;
+    }
+
+    const current = controller.getFilters().assignee ?? ASSIGNEE_FILTER_ALL;
+    let next = ASSIGNEE_FILTER_ALL;
+    if (value && value !== ASSIGNEE_FILTER_ALL) {
+      next = current === value ? ASSIGNEE_FILTER_ALL : value;
+    }
+    if (typeof controller.setAssignee === 'function') {
+      controller.setAssignee(next);
+    }
+
+    const select = document.getElementById('flt-assignee');
+    if (select) {
+      select.value = next;
+    }
+  }
+
+  function createTaskPageBase(config = {}) {
+    const {
+      viewKey,
+      headerOptions,
+      filtersContainer = document.getElementById('filters-bar'),
+      workloadContainer = document.getElementById('workload-summary'),
+      onRender,
+      onInit,
+      onRealtimeUpdate,
+      onSave,
+      onReload,
+      onApiChanged,
+      getStatuses,
+      getActiveAssignee,
+      highlightPredicate,
+      onSelectAssignee,
+      logLabel = viewKey || 'task-page',
+    } = config;
+
+    let apiRef = null;
+    let runModeRef = 'mock';
+
+    const context = {
+      getApi: () => apiRef,
+      getRunMode: () => runModeRef,
+      headerController: null,
+      filterController: null,
+      workloadSummary: null,
+    };
+
+    if (window.TaskAppHeader && typeof window.TaskAppHeader.initHeader === 'function') {
+      context.headerController = window.TaskAppHeader.initHeader(headerOptions || {});
+    }
+
+    if (typeof createController === 'function') {
+      context.filterController = createController({
+        container: filtersContainer,
+        viewKey,
+        onChange: () => {
+          if (typeof onRender === 'function') {
+            onRender(context);
+          }
+        },
+        normalizeStatusLabel,
+        parseISO,
+        getDueFilterPreset,
+      });
+    }
+
+    if (typeof createWorkloadSummary === 'function') {
+      const highlight = typeof highlightPredicate === 'function'
+        ? (entry) => highlightPredicate(entry, context)
+        : DEFAULT_WORKLOAD_HIGHLIGHT;
+
+      const resolveActiveAssignee = () => {
+        if (typeof getActiveAssignee === 'function') {
+          return getActiveAssignee(context);
+        }
+        const controller = context.filterController;
+        if (controller && typeof controller.getFilters === 'function') {
+          return controller.getFilters().assignee ?? ASSIGNEE_FILTER_ALL;
+        }
+        return ASSIGNEE_FILTER_ALL;
+      };
+
+      context.workloadSummary = createWorkloadSummary({
+        container: workloadContainer,
+        getStatuses: () => (typeof getStatuses === 'function' ? getStatuses(context) : []),
+        normalizeStatusLabel,
+        unassignedKey: ASSIGNEE_FILTER_UNASSIGNED,
+        unassignedLabel: ASSIGNEE_UNASSIGNED_LABEL,
+        allKey: ASSIGNEE_FILTER_ALL,
+        getActiveAssignee: resolveActiveAssignee,
+        getDueState,
+        highlightPredicate: highlight,
+        onSelectAssignee: (value) => {
+          if (typeof onSelectAssignee === 'function') {
+            onSelectAssignee(value, context);
+          } else {
+            defaultAssigneeSelectHandler(value, context);
+          }
+        },
+      });
+    }
+
+    if (typeof setupRuntime === 'function') {
+      setupRuntime({
+        mockApiFactory: createMockApi,
+        onApiChanged: ({ api, runMode }) => {
+          apiRef = api;
+          runModeRef = runMode;
+          if (typeof onApiChanged === 'function') {
+            onApiChanged({ api, runMode }, context);
+          } else {
+            console.log(`[${logLabel}] run mode:`, runModeRef);
+          }
+        },
+        onInit: async () => {
+          try {
+            if (typeof onInit === 'function') {
+              await onInit(context);
+            }
+            if (runModeRef === 'pywebview') {
+              markInitialExcelLoadFlag?.();
+            }
+          } catch (err) {
+            resetInitialExcelLoadFlag?.();
+            throw err;
+          }
+        },
+        onRealtimeUpdate: (payload) => {
+          if (typeof onRealtimeUpdate === 'function') {
+            onRealtimeUpdate(payload, context);
+          }
+        },
+      });
+    }
+
+    if (typeof bindExcelActions === 'function') {
+      bindExcelActions({
+        onSave: () => {
+          if (typeof onSave === 'function') {
+            onSave(context);
+          }
+        },
+        onReload: () => {
+          if (typeof onReload === 'function') {
+            onReload(context);
+          }
+        },
+      });
+    }
+
+    return context;
+  }
+
+  window.TaskPageBase = {
+    createTaskPageBase,
+  };
+})();


### PR DESCRIPTION
## Summary
- add a shared page helper that encapsulates runtime, filter, and workload summary setup
- refactor the kanban board and list scripts to use the helper and streamline filter/workload access
- include the new helper in both task page HTML files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691504337fd883229788099b05e6782f)