### PR TITLE
Refactor filter preset handling into shared utility

### DIFF
--- a/frontend/pages/calendar.html
+++ b/frontend/pages/calendar.html
@@ -127,6 +127,7 @@
 
   <script src="../scripts/appValidation.js" defer></script>
   <script src="../scripts/appPresets.js" defer></script>
+  <script src="../scripts/filterPresets.js" defer></script>
   <script src="../scripts/common.js" defer></script>
   <script src="../scripts/appRuntime.js" defer></script>
   <script src="../scripts/header.js" defer></script>

--- a/frontend/pages/timeline.html
+++ b/frontend/pages/timeline.html
@@ -143,6 +143,7 @@
 
   <script src="../scripts/appValidation.js" defer></script>
   <script src="../scripts/appPresets.js" defer></script>
+  <script src="../scripts/filterPresets.js" defer></script>
   <script src="../scripts/common.js" defer></script>
   <script src="../scripts/appRuntime.js" defer></script>
   <script src="../scripts/header.js" defer></script>

--- a/frontend/scripts/calendar.js
+++ b/frontend/scripts/calendar.js
@@ -27,11 +27,7 @@ const {
 } = window.TaskValidation || {};
 const { createExcelSyncHandlers } = window.TaskExcelSync || {};
 
-const presetApi = window.TaskPresets || {};
-const loadFilterPresets = presetApi.load || (() => ({ presets: [], lastApplied: null }));
-const saveFilterPreset = presetApi.save || (() => ({ presets: [] }));
-const deleteFilterPreset = presetApi.remove || (() => ({ presets: [], removed: false }));
-const applyFilterPreset = presetApi.apply || (() => ({ presets: [], applied: null }));
+const { createFilterPresetManager } = window.TaskFilterPresets || {};
 
 let api;
 let RUN_MODE = 'mock';
@@ -48,24 +44,38 @@ let FILTERS = {
   month: '',
 };
 
-const FILTER_PRESET_VIEW_KEY = 'calendar';
-let FILTER_PRESETS = [];
-let ACTIVE_FILTER_PRESET = '';
-let PRESET_INITIAL_APPLIED = false;
-
-function initializeFilterPresetsState() {
-  try {
-    const { presets, lastApplied } = loadFilterPresets(FILTER_PRESET_VIEW_KEY) || {};
-    FILTER_PRESETS = Array.isArray(presets) ? presets : [];
-    ACTIVE_FILTER_PRESET = lastApplied?.name || '';
-  } catch (err) {
-    console.warn('[calendar] failed to load filter presets', err);
-    FILTER_PRESETS = [];
-    ACTIVE_FILTER_PRESET = '';
-  }
-}
-
-initializeFilterPresetsState();
+const filterPresetManager = typeof createFilterPresetManager === 'function'
+  ? createFilterPresetManager({
+      viewKey: 'calendar',
+      selectors: {
+        select: '#calendar-preset',
+        apply: '#btn-calendar-preset-apply',
+        save: '#btn-calendar-preset-save',
+        delete: '#btn-calendar-preset-delete',
+      },
+      serialize: () => {
+        syncFiltersFromUI();
+        return {
+          month: FILTERS.month || '',
+        };
+      },
+      applyToUI: (raw) => {
+        const data = raw && typeof raw === 'object' ? raw : {};
+        const monthValue = String(data.month ?? '').trim();
+        FILTERS.month = monthValue;
+        applyFiltersToUI();
+        syncFiltersFromUI();
+        updateMonthLabel();
+        renderCalendar();
+        renderBacklog();
+      },
+    })
+  : {
+      maybeApplyInitialPreset: () => {},
+      updateUI: () => {},
+      getActivePresetName: () => '',
+      reload: () => {},
+    };
 
 const headerController = window.TaskAppHeader?.initHeader({
   title: 'タスク・カレンダー',
@@ -112,7 +122,7 @@ if (typeof createExcelSyncHandlers === 'function') {
       renderLegend();
       renderCalendar();
       renderBacklog();
-      updateFilterPresetUI();
+      filterPresetManager.updateUI();
       updateHeaderDueSummary(TASKS);
 
       if (typeof closeModal === 'function') {
@@ -143,154 +153,6 @@ function applyFiltersToUI() {
   }
 }
 
-function serializeFiltersForPreset() {
-  return {
-    month: FILTERS.month || '',
-  };
-}
-
-function applyPresetFilters(raw) {
-  const data = raw && typeof raw === 'object' ? raw : {};
-  const monthValue = String(data.month ?? '').trim();
-  FILTERS.month = monthValue;
-  applyFiltersToUI();
-}
-
-function maybeApplyInitialPreset() {
-  if (PRESET_INITIAL_APPLIED) return;
-  PRESET_INITIAL_APPLIED = true;
-  if (!ACTIVE_FILTER_PRESET) return;
-  const preset = FILTER_PRESETS.find(item => item?.name === ACTIVE_FILTER_PRESET);
-  if (!preset) {
-    ACTIVE_FILTER_PRESET = '';
-    return;
-  }
-  applyPresetFilters(preset.filters);
-}
-
-function ensureFilterPresetHandlers() {
-  const select = document.getElementById('calendar-preset');
-  const applyBtn = document.getElementById('btn-calendar-preset-apply');
-  const saveBtn = document.getElementById('btn-calendar-preset-save');
-  const deleteBtn = document.getElementById('btn-calendar-preset-delete');
-  if (!select || !applyBtn || !saveBtn || !deleteBtn) return;
-  if (select.dataset.bound === '1') return;
-  select.dataset.bound = '1';
-
-  const refreshButtonState = () => {
-    const selected = select.value;
-    const exists = Boolean(selected) && FILTER_PRESETS.some(preset => preset?.name === selected);
-    applyBtn.disabled = !exists;
-    deleteBtn.disabled = !exists;
-  };
-
-  select.addEventListener('change', () => {
-    ACTIVE_FILTER_PRESET = select.value;
-    refreshButtonState();
-  });
-
-  applyBtn.addEventListener('click', () => {
-    const targetName = select.value;
-    if (!targetName) {
-      alert('プリセットを選択してください。');
-      return;
-    }
-    const result = applyFilterPreset(FILTER_PRESET_VIEW_KEY, targetName, (filters) => {
-      applyPresetFilters(filters);
-      return true;
-    });
-    FILTER_PRESETS = result.presets;
-    if (result.applied) {
-      ACTIVE_FILTER_PRESET = result.applied.name;
-      PRESET_INITIAL_APPLIED = true;
-      applyFiltersToUI();
-      updateMonthLabel();
-      renderCalendar();
-      renderBacklog();
-    } else {
-      alert('選択したプリセットが見つかりません。');
-      updateFilterPresetUI();
-    }
-  });
-
-  saveBtn.addEventListener('click', () => {
-    const defaultName = select.value || '';
-    const name = window.prompt('プリセット名を入力してください', defaultName);
-    if (name === null) return;
-    const trimmed = name.trim();
-    if (!trimmed) {
-      alert('プリセット名を入力してください。');
-      return;
-    }
-    syncFiltersFromUI();
-    const payload = serializeFiltersForPreset();
-    const result = saveFilterPreset(FILTER_PRESET_VIEW_KEY, trimmed, payload);
-    FILTER_PRESETS = result.presets;
-    if (result.saved) {
-      ACTIVE_FILTER_PRESET = result.saved.name;
-      PRESET_INITIAL_APPLIED = true;
-    }
-    updateFilterPresetUI();
-  });
-
-  deleteBtn.addEventListener('click', () => {
-    const targetName = select.value;
-    if (!targetName) {
-      alert('削除するプリセットを選択してください。');
-      return;
-    }
-    if (!window.confirm(`プリセット「${targetName}」を削除しますか？`)) {
-      return;
-    }
-    const result = deleteFilterPreset(FILTER_PRESET_VIEW_KEY, targetName);
-    FILTER_PRESETS = result.presets;
-    if (ACTIVE_FILTER_PRESET === targetName) {
-      ACTIVE_FILTER_PRESET = '';
-    }
-    updateFilterPresetUI();
-  });
-
-  refreshButtonState();
-}
-
-function updateFilterPresetUI() {
-  ensureFilterPresetHandlers();
-  const select = document.getElementById('calendar-preset');
-  const applyBtn = document.getElementById('btn-calendar-preset-apply');
-  const deleteBtn = document.getElementById('btn-calendar-preset-delete');
-  if (!select) return;
-
-  const previousValue = select.value;
-  select.innerHTML = '';
-
-  const placeholder = document.createElement('option');
-  placeholder.value = '';
-  placeholder.textContent = '（プリセット未選択）';
-  select.appendChild(placeholder);
-
-  FILTER_PRESETS.forEach(preset => {
-    if (!preset || typeof preset.name !== 'string') return;
-    const opt = document.createElement('option');
-    opt.value = preset.name;
-    opt.textContent = preset.name;
-    select.appendChild(opt);
-  });
-
-  let nextValue = '';
-  if (ACTIVE_FILTER_PRESET && FILTER_PRESETS.some(p => p?.name === ACTIVE_FILTER_PRESET)) {
-    nextValue = ACTIVE_FILTER_PRESET;
-  } else if (FILTER_PRESETS.some(p => p?.name === previousValue)) {
-    nextValue = previousValue;
-    ACTIVE_FILTER_PRESET = previousValue;
-  } else {
-    ACTIVE_FILTER_PRESET = '';
-  }
-
-  select.value = nextValue;
-  const hasSelection = Boolean(select.value);
-  if (applyBtn) applyBtn.disabled = !hasSelection;
-  if (deleteBtn) deleteBtn.disabled = !hasSelection;
-}
 
 if (typeof setupRuntime === 'function') {
   setupRuntime({
@@ -361,13 +223,13 @@ async function init(force = false) {
   }
 
   ensureMonthDefault();
-  maybeApplyInitialPreset();
+  filterPresetManager.maybeApplyInitialPreset();
   applyFiltersToUI();
   syncFiltersFromUI();
   renderLegend();
   renderCalendar();
   renderBacklog();
-  updateFilterPresetUI();
+  filterPresetManager.updateUI();
   updateHeaderDueSummary(TASKS);
 }
 
@@ -432,13 +294,13 @@ async function applyStateFromPayload(payload, { fallbackToApi = false } = {}) {
     : VALIDATIONS;
 
   ensureMonthDefault();
-  maybeApplyInitialPreset();
+  filterPresetManager.maybeApplyInitialPreset();
   applyFiltersToUI();
   syncFiltersFromUI();
   renderLegend();
   renderCalendar();
   renderBacklog();
-  updateFilterPresetUI();
+  filterPresetManager.updateUI();
 }
 
 function wireControls() {
@@ -459,7 +321,7 @@ function wireControls() {
     updateMonthLabel();
     renderCalendar();
     renderBacklog();
-    updateFilterPresetUI();
+    filterPresetManager.updateUI();
   };
 
   if (prevBtn) {
@@ -474,7 +336,7 @@ function wireControls() {
       updateMonthLabel();
       renderCalendar();
       renderBacklog();
-      updateFilterPresetUI();
+      filterPresetManager.updateUI();
     });
   }
 

--- a/frontend/scripts/filterPresets.js
+++ b/frontend/scripts/filterPresets.js
@@ -1,0 +1,205 @@
+(function (global) {
+  const noop = () => {};
+
+  function getPresetApi() {
+    const api = global.TaskPresets || {};
+    return {
+      load: typeof api.load === 'function' ? api.load : () => ({ presets: [], lastApplied: null }),
+      save: typeof api.save === 'function' ? api.save : () => ({ presets: [] }),
+      remove: typeof api.remove === 'function' ? api.remove : () => ({ presets: [], removed: false }),
+      apply: typeof api.apply === 'function' ? api.apply : () => ({ presets: [], applied: null }),
+    };
+  }
+
+  function resolveElement(selector) {
+    if (!selector) return null;
+    if (selector instanceof Element) return selector;
+    if (typeof selector === 'string') {
+      return document.querySelector(selector);
+    }
+    return null;
+  }
+
+  function createFilterPresetManager({ viewKey, selectors = {}, serialize = noop, applyToUI = noop } = {}) {
+    if (!viewKey) {
+      throw new Error('createFilterPresetManager: viewKey is required');
+    }
+
+    const api = getPresetApi();
+    let presets = [];
+    let activePresetName = '';
+    let initialApplied = false;
+    let handlersBound = false;
+
+    function loadState() {
+      try {
+        const { presets: loaded, lastApplied } = api.load(viewKey) || {};
+        presets = Array.isArray(loaded) ? loaded : [];
+        activePresetName = lastApplied?.name || '';
+      } catch (err) {
+        console.warn(`[${viewKey}] failed to load filter presets`, err);
+        presets = [];
+        activePresetName = '';
+      }
+    }
+
+    loadState();
+
+    function getElements() {
+      return {
+        select: resolveElement(selectors.select || selectors.dropdown || selectors.preset),
+        applyBtn: resolveElement(selectors.apply),
+        saveBtn: resolveElement(selectors.save),
+        deleteBtn: resolveElement(selectors.delete || selectors.remove),
+      };
+    }
+
+    function refreshButtonState(selectEl, applyBtn, deleteBtn) {
+      const selected = selectEl?.value || '';
+      const exists = Boolean(selected) && presets.some(preset => preset?.name === selected);
+      if (applyBtn) applyBtn.disabled = !exists;
+      if (deleteBtn) deleteBtn.disabled = !exists;
+    }
+
+    function updateOptions(selectEl) {
+      if (!selectEl) return;
+      const previousValue = selectEl.value;
+      selectEl.innerHTML = '';
+
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = '（プリセット未選択）';
+      selectEl.appendChild(placeholder);
+
+      presets.forEach(preset => {
+        if (!preset || typeof preset.name !== 'string') return;
+        const opt = document.createElement('option');
+        opt.value = preset.name;
+        opt.textContent = preset.name;
+        selectEl.appendChild(opt);
+      });
+
+      let nextValue = '';
+      if (activePresetName && presets.some(p => p?.name === activePresetName)) {
+        nextValue = activePresetName;
+      } else if (presets.some(p => p?.name === previousValue)) {
+        nextValue = previousValue;
+        activePresetName = previousValue;
+      } else {
+        activePresetName = '';
+      }
+
+      selectEl.value = nextValue;
+    }
+
+    function ensureHandlers() {
+      if (handlersBound) return;
+      const { select, applyBtn, saveBtn, deleteBtn } = getElements();
+      if (!select || !applyBtn || !saveBtn || !deleteBtn) return;
+
+      const handleSelectionChange = () => {
+        activePresetName = select.value || '';
+        refreshButtonState(select, applyBtn, deleteBtn);
+      };
+
+      select.addEventListener('change', handleSelectionChange);
+
+      applyBtn.addEventListener('click', () => {
+        const targetName = select.value || '';
+        if (!targetName) {
+          alert('プリセットを選択してください。');
+          return;
+        }
+        const result = api.apply(viewKey, targetName, (filters) => {
+          applyToUI(filters);
+          return true;
+        });
+        presets = result.presets;
+        if (result.applied) {
+          activePresetName = result.applied.name;
+          initialApplied = true;
+          updateUI();
+        } else {
+          alert('選択したプリセットが見つかりません。');
+          loadState();
+          updateUI();
+        }
+      });
+
+      saveBtn.addEventListener('click', () => {
+        const defaultName = select.value || '';
+        const name = window.prompt('プリセット名を入力してください', defaultName);
+        if (name === null) return;
+        const trimmed = name.trim();
+        if (!trimmed) {
+          alert('プリセット名を入力してください。');
+          return;
+        }
+        const payload = serialize();
+        const result = api.save(viewKey, trimmed, payload);
+        presets = result.presets;
+        if (result.saved) {
+          activePresetName = result.saved.name;
+          initialApplied = true;
+        }
+        updateUI();
+      });
+
+      deleteBtn.addEventListener('click', () => {
+        const targetName = select.value || '';
+        if (!targetName) {
+          alert('削除するプリセットを選択してください。');
+          return;
+        }
+        if (!window.confirm(`プリセット「${targetName}」を削除しますか？`)) {
+          return;
+        }
+        const result = api.remove(viewKey, targetName);
+        presets = result.presets;
+        if (activePresetName === targetName) {
+          activePresetName = '';
+        }
+        updateUI();
+      });
+
+      handlersBound = true;
+      refreshButtonState(select, applyBtn, deleteBtn);
+    }
+
+    function updateUI() {
+      const { select, applyBtn, deleteBtn } = getElements();
+      if (select) {
+        updateOptions(select);
+      }
+      refreshButtonState(select, applyBtn, deleteBtn);
+      ensureHandlers();
+    }
+
+    function maybeApplyInitialPreset() {
+      if (initialApplied) return;
+      initialApplied = true;
+      if (!activePresetName) return;
+      const preset = presets.find(item => item?.name === activePresetName);
+      if (!preset) {
+        activePresetName = '';
+        updateUI();
+        return;
+      }
+      applyToUI(preset.filters);
+    }
+
+    return {
+      maybeApplyInitialPreset,
+      updateUI,
+      getActivePresetName: () => activePresetName,
+      reload: () => {
+        loadState();
+        updateUI();
+      },
+    };
+  }
+
+  global.TaskFilterPresets = {
+    createFilterPresetManager,
+  };
+})(window);

--- a/frontend/scripts/timeline.js
+++ b/frontend/scripts/timeline.js
@@ -25,11 +25,7 @@ const {
 } = window.TaskValidation || {};
 const { createExcelSyncHandlers } = window.TaskExcelSync || {};
 
-const presetApi = window.TaskPresets || {};
-const loadFilterPresets = presetApi.load || (() => ({ presets: [], lastApplied: null }));
-const saveFilterPreset = presetApi.save || (() => ({ presets: [] }));
-const deleteFilterPreset = presetApi.remove || (() => ({ presets: [], removed: false }));
-const applyFilterPreset = presetApi.apply || (() => ({ presets: [], applied: null }));
+const { createFilterPresetManager } = window.TaskFilterPresets || {};
 
 let api;
 let RUN_MODE = 'mock';
@@ -49,24 +45,47 @@ let FILTERS = {
   assignee: ASSIGNEE_FILTER_ALL,
 };
 
-const FILTER_PRESET_VIEW_KEY = 'timeline';
-let FILTER_PRESETS = [];
-let ACTIVE_FILTER_PRESET = '';
-let PRESET_INITIAL_APPLIED = false;
-
-function initializeFilterPresetsState() {
-  try {
-    const { presets, lastApplied } = loadFilterPresets(FILTER_PRESET_VIEW_KEY) || {};
-    FILTER_PRESETS = Array.isArray(presets) ? presets : [];
-    ACTIVE_FILTER_PRESET = lastApplied?.name || '';
-  } catch (err) {
-    console.warn('[timeline] failed to load filter presets', err);
-    FILTER_PRESETS = [];
-    ACTIVE_FILTER_PRESET = '';
-  }
-}
-
-initializeFilterPresetsState();
+const filterPresetManager = typeof createFilterPresetManager === 'function'
+  ? createFilterPresetManager({
+      viewKey: 'timeline',
+      selectors: {
+        select: '#timeline-preset',
+        apply: '#btn-timeline-preset-apply',
+        save: '#btn-timeline-preset-save',
+        delete: '#btn-timeline-preset-delete',
+      },
+      serialize: () => {
+        syncFiltersFromUI();
+        return {
+          range: {
+            from: FILTERS.range.from || '',
+            to: FILTERS.range.to || '',
+          },
+          assignee: FILTERS.assignee || ASSIGNEE_FILTER_ALL,
+        };
+      },
+      applyToUI: (raw) => {
+        const data = raw && typeof raw === 'object' ? raw : {};
+        const range = data.range && typeof data.range === 'object' ? data.range : {};
+        FILTERS.range = {
+          from: String(range.from ?? ''),
+          to: String(range.to ?? ''),
+        };
+        const assignee = String(data.assignee ?? '').trim();
+        FILTERS.assignee = assignee || ASSIGNEE_FILTER_ALL;
+        applyFiltersToUI();
+        syncFiltersFromUI();
+        renderSummary();
+        renderAssigneeFilter();
+        renderTimeline();
+      },
+    })
+  : {
+      maybeApplyInitialPreset: () => {},
+      updateUI: () => {},
+      getActivePresetName: () => '',
+      reload: () => {},
+    };
 
 const headerController = window.TaskAppHeader?.initHeader({
   title: '担当者タイムライン',
@@ -158,163 +177,6 @@ function applyFiltersToUI() {
   }
 }
 
-function serializeFiltersForPreset() {
-  return {
-    range: {
-      from: FILTERS.range.from || '',
-      to: FILTERS.range.to || '',
-    },
-    assignee: FILTERS.assignee || ASSIGNEE_FILTER_ALL,
-  };
-}
-
-function applyPresetFilters(raw) {
-  const data = raw && typeof raw === 'object' ? raw : {};
-  const range = data.range && typeof data.range === 'object' ? data.range : {};
-  FILTERS.range = {
-    from: String(range.from ?? ''),
-    to: String(range.to ?? ''),
-  };
-  const assignee = String(data.assignee ?? '').trim();
-  FILTERS.assignee = assignee || ASSIGNEE_FILTER_ALL;
-  applyFiltersToUI();
-}
-
-function maybeApplyInitialPreset() {
-  if (PRESET_INITIAL_APPLIED) return;
-  PRESET_INITIAL_APPLIED = true;
-  if (!ACTIVE_FILTER_PRESET) return;
-  const preset = FILTER_PRESETS.find(item => item?.name === ACTIVE_FILTER_PRESET);
-  if (!preset) {
-    ACTIVE_FILTER_PRESET = '';
-    return;
-  }
-  applyPresetFilters(preset.filters);
-}
-
-function ensureFilterPresetHandlers() {
-  const select = document.getElementById('timeline-preset');
-  const applyBtn = document.getElementById('btn-timeline-preset-apply');
-  const saveBtn = document.getElementById('btn-timeline-preset-save');
-  const deleteBtn = document.getElementById('btn-timeline-preset-delete');
-  if (!select || !applyBtn || !saveBtn || !deleteBtn) return;
-  if (select.dataset.bound === '1') return;
-  select.dataset.bound = '1';
-
-  const refreshButtonState = () => {
-    const selected = select.value;
-    const exists = Boolean(selected) && FILTER_PRESETS.some(preset => preset?.name === selected);
-    applyBtn.disabled = !exists;
-    deleteBtn.disabled = !exists;
-  };
-
-  select.addEventListener('change', () => {
-    ACTIVE_FILTER_PRESET = select.value;
-    refreshButtonState();
-  });
-
-  applyBtn.addEventListener('click', () => {
-    const targetName = select.value;
-    if (!targetName) {
-      alert('プリセットを選択してください。');
-      return;
-    }
-    const result = applyFilterPreset(FILTER_PRESET_VIEW_KEY, targetName, (filters) => {
-      applyPresetFilters(filters);
-      return true;
-    });
-    FILTER_PRESETS = result.presets;
-    if (result.applied) {
-      ACTIVE_FILTER_PRESET = result.applied.name;
-      PRESET_INITIAL_APPLIED = true;
-      syncFiltersFromUI();
-      renderSummary();
-      renderAssigneeFilter();
-      renderTimeline();
-    } else {
-      alert('選択したプリセットが見つかりません。');
-      updateFilterPresetUI();
-    }
-  });
-
-  saveBtn.addEventListener('click', () => {
-    const defaultName = select.value || '';
-    const name = window.prompt('プリセット名を入力してください', defaultName);
-    if (name === null) return;
-    const trimmed = name.trim();
-    if (!trimmed) {
-      alert('プリセット名を入力してください。');
-      return;
-    }
-    syncFiltersFromUI();
-    const payload = serializeFiltersForPreset();
-    const result = saveFilterPreset(FILTER_PRESET_VIEW_KEY, trimmed, payload);
-    FILTER_PRESETS = result.presets;
-    if (result.saved) {
-      ACTIVE_FILTER_PRESET = result.saved.name;
-      PRESET_INITIAL_APPLIED = true;
-    }
-    updateFilterPresetUI();
-  });
-
-  deleteBtn.addEventListener('click', () => {
-    const targetName = select.value;
-    if (!targetName) {
-      alert('削除するプリセットを選択してください。');
-      return;
-    }
-    if (!window.confirm(`プリセット「${targetName}」を削除しますか？`)) {
-      return;
-    }
-    const result = deleteFilterPreset(FILTER_PRESET_VIEW_KEY, targetName);
-    FILTER_PRESETS = result.presets;
-    if (ACTIVE_FILTER_PRESET === targetName) {
-      ACTIVE_FILTER_PRESET = '';
-    }
-    updateFilterPresetUI();
-  });
-
-  refreshButtonState();
-}
-
-function updateFilterPresetUI() {
-  ensureFilterPresetHandlers();
-  const select = document.getElementById('timeline-preset');
-  const applyBtn = document.getElementById('btn-timeline-preset-apply');
-  const deleteBtn = document.getElementById('btn-timeline-preset-delete');
-  if (!select) return;
-
-  const previousValue = select.value;
-  select.innerHTML = '';
-
-  const placeholder = document.createElement('option');
-  placeholder.value = '';
-  placeholder.textContent = '（プリセット未選択）';
-  select.appendChild(placeholder);
-
-  FILTER_PRESETS.forEach(preset => {
-    if (!preset || typeof preset.name !== 'string') return;
-    const opt = document.createElement('option');
-    opt.value = preset.name;
-    opt.textContent = preset.name;
-    select.appendChild(opt);
-  });
-
-  let nextValue = '';
-  if (ACTIVE_FILTER_PRESET && FILTER_PRESETS.some(p => p?.name === ACTIVE_FILTER_PRESET)) {
-    nextValue = ACTIVE_FILTER_PRESET;
-  } else if (FILTER_PRESETS.some(p => p?.name === previousValue)) {
-    nextValue = previousValue;
-    ACTIVE_FILTER_PRESET = previousValue;
-  } else {
-    ACTIVE_FILTER_PRESET = '';
-  }
-
-  select.value = nextValue;
-  const hasSelection = Boolean(select.value);
-  if (applyBtn) applyBtn.disabled = !hasSelection;
-  if (deleteBtn) deleteBtn.disabled = !hasSelection;
-}
 
 if (typeof setupRuntime === 'function') {
   setupRuntime({
@@ -385,7 +247,7 @@ async function init(force = false) {
   }
 
   ensureRangeDefaults();
-  maybeApplyInitialPreset();
+  filterPresetManager.maybeApplyInitialPreset();
   syncFiltersFromUI();
   renderSummary();
   renderLegend();
@@ -456,7 +318,7 @@ async function applyStateFromPayload(payload, { fallbackToApi = false } = {}) {
     : VALIDATIONS;
 
   ensureRangeDefaults();
-  maybeApplyInitialPreset();
+  filterPresetManager.maybeApplyInitialPreset();
   syncFiltersFromUI();
   renderSummary();
   renderLegend();
@@ -627,7 +489,7 @@ function renderAssigneeFilter() {
     select.value = ASSIGNEE_FILTER_ALL;
   }
   FILTERS.assignee = select.value;
-  updateFilterPresetUI();
+  filterPresetManager.updateUI();
 }
 
 function renderLegend() {


### PR DESCRIPTION
## Summary
- add a shared filter preset manager utility that encapsulates loading, applying, saving, and deleting presets
- update the timeline and calendar views to use the shared manager with view-specific serialization and UI hooks
- include the new utility script on the timeline and calendar pages

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691509fac1e48322b48e1a0a1942a6aa)